### PR TITLE
add ProgressBar with new Toolbar to show loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,8 +34,8 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.google.android.material:material:1.2.0'
 }
 
 def props = new Properties()

--- a/app/src/main/assets/viewer.js
+++ b/app/src/main/assets/viewer.js
@@ -59,6 +59,7 @@ function display(newCanvas, zoom) {
     if (!zoom) {
         scrollTo(0, 0);
     }
+    channel.hideProgressBar();
 }
 
 function renderPage(pageNumber, zoom, prerender, prerenderTrigger=0) {

--- a/app/src/main/res/layout/webview.xml
+++ b/app/src/main/res/layout/webview.xml
@@ -1,5 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<WebView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/webview"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent" />
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/appCoordinatorLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/webview"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:visibility="visible" />
+
+    <LinearLayout
+        android:id="@+id/toolbarProgressBarHolder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:fitsSystemWindows="true"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appBarLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:animateLayoutChanges="true"
+            android:background="?attr/colorPrimary"
+            android:fitsSystemWindows="true"
+            android:theme="@style/AppTheme">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:fitsSystemWindows="true"
+                android:minHeight="?attr/actionBarSize"
+                android:theme="@style/AppTheme"
+                app:menu="@menu/pdf_viewer" />
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="16dp"
+            android:layout_marginTop="-6dp"
+            android:layout_marginBottom="-6dp"
+            android:background="?attr/colorPrimary"
+            android:fitsSystemWindows="false"
+            android:indeterminate="true"
+            android:theme="@style/AppTheme"
+            android:visibility="gone"
+            tools:visibility="visible" />
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,8 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
+    <style name="AppTheme" parent="Theme.AppCompat.NoActionBar">
     </style>
 
 </resources>


### PR DESCRIPTION
On hold until https://github.com/GrapheneOS/PdfViewer/pull/72 is looked at

A ProgressBar is displayed when a page is rendering; the ProgressBar is
hidden after the page has been displayed to the screen. In order to make
the ProgressBar show under the ActionBar, we use our own Toolbar
integrated into the Activity's layout instead of the one provided by the
system. (This also gives us a bit more control over styling.)

The ProgressBar is set to indeterminate. Zooming in does not show the
ProgressBar.

Closes #29 