### PR TITLE
move initial showSystemUi call to loadPdf

### DIFF
--- a/app/src/main/java/org/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/org/grapheneos/pdfviewer/PdfViewer.java
@@ -29,14 +29,14 @@ import androidx.loader.content.Loader;
 
 import com.google.android.material.snackbar.Snackbar;
 
+import org.grapheneos.pdfviewer.fragment.DocumentPropertiesFragment;
+import org.grapheneos.pdfviewer.fragment.JumpToPageFragment;
+import org.grapheneos.pdfviewer.loader.DocumentPropertiesLoader;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
-
-import org.grapheneos.pdfviewer.fragment.DocumentPropertiesFragment;
-import org.grapheneos.pdfviewer.fragment.JumpToPageFragment;
-import org.grapheneos.pdfviewer.loader.DocumentPropertiesLoader;
 
 public class PdfViewer extends AppCompatActivity implements LoaderManager.LoaderCallbacks<List<CharSequence>> {
     public static final String TAG = "PdfViewer";
@@ -234,8 +234,6 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
             }
         });
 
-        showSystemUi();
-
         GestureHelper.attach(PdfViewer.this, mWebView,
                 new GestureHelper.GestureListener() {
                     @Override
@@ -338,6 +336,8 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
             snackbar.setText(R.string.io_error).show();
             return;
         }
+
+        showSystemUi();
         mWebView.loadUrl("https://localhost/viewer.html");
     }
 


### PR DESCRIPTION
The reasoning for calling showSystemUi() in the onCreate method before was to make the transitions for immersive mode more smooth. However, it's only needed when the PDF has actually loaded, i.e. when the immersive mode makes sense to use.

Before, Snackbars were partially covered by the navigation UI due to the showSystemUi() setting the View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION flag. Moving it so that the function is only called when a PDF is loaded fixes this issue.

Fixes https://github.com/GrapheneOS/PdfViewer/issues/54