### PR TITLE
gradle: replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     gradle.projectsEvaluated {


### PR DESCRIPTION
Closes #80 

trove4j is now on Maven Central, allowing us to remove JCenter completely: https://youtrack.jetbrains.com/issue/IDEA-261387#focus=Comments-27-4820597.0-0