### PR TITLE
Target + Compile for SDK 32 (Android 12L)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,6 @@ android {
 }
 
 dependencies {
-    implementation("androidx.appcompat:appcompat:1.4.0")
-    implementation("com.google.android.material:material:1.4.0")
+    implementation("androidx.appcompat:appcompat:1.4.1")
+    implementation("com.google.android.material:material:1.5.0")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,16 +25,16 @@ android {
         }
     }
 
-    compileSdk = 31
-    buildToolsVersion("31.0.0")
+    compileSdk = 32
+    buildToolsVersion = "32.0.0"
 
     defaultConfig {
         applicationId = "org.grapheneos.pdfviewer"
         minSdk = 26
-        targetSdk = 31
+        targetSdk = 32
         versionCode = 7
         versionName = versionCode.toString()
-        resConfigs("en")
+        resourceConfigurations.addAll(listOf("en"))
     }
 
     buildTypes {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath("com.android.tools.build:gradle:7.1.0-rc01")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b586e04868a22fd817c8971330fec37e298f3242eb85c374181b12d637f80302
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionSha256Sum=07a1cd283d6cfe437eb08fe08936dc1af5f12946e67dc9f5e0a9f4b948ebfd3a
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
we need to use release candidate version of gradle wrapper and the plugin for SDK 32 at the moment. also solves log4j vulnerabilities in gradle wrapper (yes. really.). release candidate of Android Studio Bumblebee is recommended as well.

Signed-off-by: June <june@eridan.me>