### PR TITLE
Create layout for the PDF viewer activity

### DIFF
--- a/app/src/main/assets/viewer.css
+++ b/app/src/main/assets/viewer.css
@@ -1,11 +1,6 @@
-body, canvas, #padding {
+body, canvas {
     padding: 0;
     margin: 0;
-}
-
-#padding {
-    min-width: 100%;
-    background: black;
 }
 
 .textLayer {

--- a/app/src/main/assets/viewer.html
+++ b/app/src/main/assets/viewer.html
@@ -7,7 +7,6 @@
         <script src="pdf.js"></script>
     </head>
     <body>
-        <div id="padding"></div>
         <canvas id="content"></canvas>
         <div id="text" class="textLayer"></div>
         <script src="viewer.js"></script>

--- a/app/src/main/assets/viewer.js
+++ b/app/src/main/assets/viewer.js
@@ -2,7 +2,6 @@
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = "/pdf.worker.js";
 
-const padding = document.getElementById("padding");
 let pdfDoc = null;
 let pageRendering = false;
 let renderPending = false;
@@ -56,7 +55,6 @@ function display(newCanvas, zoom) {
     canvas.width = newCanvas.width;
     canvas.style.height = newCanvas.style.height;
     canvas.style.width = newCanvas.style.width;
-    padding.style.width = canvas.style.width;
     canvas.getContext("2d", { alpha: false }).drawImage(newCanvas, 0, 0);
     if (!zoom) {
         scrollTo(0, 0);
@@ -199,14 +197,6 @@ function onRenderPage(zoom) {
 function isTextSelected() {
     return window.getSelection().toString() !== "";
 }
-
-function updateInset() {
-    const windowInsetTop = channel.getWindowInsetTop() / window.devicePixelRatio + "px";
-    padding.style.paddingTop = windowInsetTop;
-    textLayerDiv.style.top = windowInsetTop;
-}
-
-updateInset();
 
 pdfjsLib.getDocument("https://localhost/placeholder.pdf").promise.then(function(newDoc) {
     pdfDoc = newDoc;

--- a/app/src/main/java/org/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/org/grapheneos/pdfviewer/PdfViewer.java
@@ -30,7 +30,7 @@ import androidx.loader.content.Loader;
 
 import com.google.android.material.snackbar.Snackbar;
 
-import org.grapheneos.pdfviewer.databinding.WebviewBinding;
+import org.grapheneos.pdfviewer.databinding.PdfviewerBinding;
 import org.grapheneos.pdfviewer.fragment.DocumentPropertiesFragment;
 import org.grapheneos.pdfviewer.fragment.JumpToPageFragment;
 import org.grapheneos.pdfviewer.loader.DocumentPropertiesLoader;
@@ -103,21 +103,15 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
     private float mZoomRatio = 1f;
     private int mDocumentOrientationDegrees;
     private int mDocumentState;
-    private int windowInsetTop;
     private List<CharSequence> mDocumentProperties;
     private InputStream mInputStream;
 
-    private WebviewBinding binding;
+    private PdfviewerBinding binding;
     private TextView mTextView;
     private Toast mToast;
     private Snackbar snackbar;
 
     private class Channel {
-        @JavascriptInterface
-        public int getWindowInsetTop() {
-            return windowInsetTop;
-        }
-
         @JavascriptInterface
         public int getPage() {
             return mPage;
@@ -155,20 +149,15 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
     @SuppressLint({"SetJavaScriptEnabled", "ClickableViewAccessibility"})
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        binding = WebviewBinding.inflate(getLayoutInflater());
+        binding = PdfviewerBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+        setSupportActionBar(binding.toolbar);
 
         binding.webview.setBackgroundColor(Color.TRANSPARENT);
 
         if (BuildConfig.DEBUG) {
             WebView.setWebContentsDebuggingEnabled(true);
         }
-
-        binding.webview.setOnApplyWindowInsetsListener((view, insets) -> {
-            windowInsetTop = insets.getSystemWindowInsetTop();
-            binding.webview.evaluateJavascript("updateInset()", null);
-            return insets;
-        });
 
         final WebSettings settings = binding.webview.getSettings();
         settings.setAllowContentAccess(false);
@@ -412,6 +401,7 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
                 View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
                 View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
                 View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+        getSupportActionBar().show();
     }
 
     private void hideSystemUi() {
@@ -422,6 +412,7 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
                 View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
                 View.SYSTEM_UI_FLAG_FULLSCREEN |
                 View.SYSTEM_UI_FLAG_IMMERSIVE);
+        getSupportActionBar().hide();
     }
 
     @Override

--- a/app/src/main/res/layout/pdfviewer.xml
+++ b/app/src/main/res/layout/pdfviewer.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:fitsSystemWindows="true"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="#212121"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <WebView
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/webview.xml
+++ b/app/src/main/res/layout/webview.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<WebView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/webview"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent" />

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,9 +1,13 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
+        <item name="colorPrimary">#DEFFFFFF</item>
         <item name="android:windowBackground">#000000</item>
+        <item name="android:statusBarColor">#212121</item>
     </style>
+
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Dark" />
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,8 +1,14 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
+        <item name="colorPrimary">#000000</item>
+        <item name="android:statusBarColor">#212121</item>
     </style>
+
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
 </resources>


### PR DESCRIPTION
Updating insets is no longer necessary because the layout reserves the
space for the top app bar and frees it up in full-screen mode so the
WebView can fill the entire screen.