### PR TITLE
Disable animated layout changes for the top app bar

### DIFF
--- a/app/src/main/res/layout/pdfviewer.xml
+++ b/app/src/main/res/layout/pdfviewer.xml
@@ -7,7 +7,6 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:animateLayoutChanges="true"
         android:fitsSystemWindows="true"
         android:theme="@style/AppTheme.AppBarOverlay">
 


### PR DESCRIPTION
At least temporarily. Prevents unsightly layout shifts