### PR TITLE
Target SDK 12L/12.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId = "app.grapheneos.pdfviewer"
         minSdk = 26
-        targetSdk = 31
+        targetSdk = 32
         versionCode = 12
         versionName = versionCode.toString()
         resourceConfigurations.add("en")


### PR DESCRIPTION
GrapheneOS is now on 12.1

Signed-off-by: June <june@eridan.me>