### PR TITLE
Support for progress bar (while loading a large PDF)

### DIFF
--- a/app/src/main/assets/viewer.css
+++ b/app/src/main/assets/viewer.css
@@ -79,3 +79,14 @@ body {
 .textLayer .endOfContent.active {
     top: 0;
 }
+
+#loading-bar-container {
+  width: 100%;
+  background-color: #bbdefb;
+}
+
+#loading-bar {
+  width: 0%;
+  height: 4px;
+  background-color: #106cc8;
+}

--- a/app/src/main/assets/viewer.html
+++ b/app/src/main/assets/viewer.html
@@ -7,6 +7,9 @@
         <script src="pdf.js"></script>
     </head>
     <body>
+        <div id="loading-bar-container">
+            <div id="loading-bar"></div>
+        </div>
         <canvas id="content"></canvas>
         <div id="text" class="textLayer"></div>
         <script src="viewer.js"></script>

--- a/app/src/main/assets/viewer.js
+++ b/app/src/main/assets/viewer.js
@@ -19,6 +19,25 @@ let useRender;
 const cache = [];
 const maxCached = 6;
 
+var loading_bar = document.getElementById("loading-bar");
+var loading_bar_container = document.getElementById("loading-bar-container");
+
+function show_progress_bar() {
+    loading_bar.style.display = "block";
+    loading_bar_container.style.display = "block";
+}
+
+function hide_progress_bar() {
+    loading_bar.style.display = "none";
+    loading_bar_container.style.display = "none";
+}
+
+function set_progress(value) {
+    if(value==0) show_progress_bar();
+    else if(value==100) hide_progress_bar();
+    else loading_bar.style.width = value + "%";
+}
+
 function maybeRenderNextPage() {
     if (renderPending) {
         pageRendering = false;
@@ -209,6 +228,14 @@ function loadDocument() {
         }
     }
 
+    loadingTask.onProgress = function(data){
+        var progress = Math.ceil((data.loaded/data.total)*100);
+        console.log("Progress: " + progress);
+        set_progress(progress);
+    }
+
+    show_progress_bar();
+
     loadingTask.promise.then(function (newDoc) {
         pdfDoc = newDoc;
         channel.setNumPages(pdfDoc.numPages);
@@ -218,7 +245,9 @@ function loadDocument() {
             console.log("getMetadata error: " + error);
         });
         renderPage(channel.getPage(), false, false);
+        hide_progress_bar();
     }, function (reason) {
+        hide_progress_bar();
         console.error(reason.name + ": " + reason.message);
     });
 }


### PR DESCRIPTION
Merging this PR would render a linear progress bar at the top of the viewer while loading a (large) PDF.

Here's a [sample pdf](https://cartographicperspectives.org/index.php/journal/article/view/cp43-complete-issue/pdf) of 100-105 mb can be used for testing