### PR TITLE
Zoom out completely on document load

### DIFF
--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
@@ -503,6 +503,12 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("application/pdf");
         openDocumentLauncher.launch(intent);
+        // zoom out to the maximum possible dimension to give the user a complete view of the page
+        zoomOutMax();
+    }
+
+    private void zoomOutMax() {
+        zoomOut(0.5f, false);
     }
 
     private void shareDocument() {


### PR DESCRIPTION
To give the user a better view of the entire page once the document loads (instead of having to manually zoom out)