### PR TITLE
Vertically and horizontally center PDF page

### DIFF
--- a/app/src/main/assets/viewer.css
+++ b/app/src/main/assets/viewer.css
@@ -6,7 +6,7 @@ body, canvas {
 canvas {
     margin: auto;
     display: block;
-    position: absolute;
+    position: fixed;
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
@@ -17,7 +17,7 @@ body {
 }
 
 .textLayer {
-    position: absolute;
+    position: fixed;
     text-align: initial;
     left: 50%;
     top: 50%;

--- a/app/src/main/assets/viewer.css
+++ b/app/src/main/assets/viewer.css
@@ -6,6 +6,10 @@ body, canvas {
 canvas {
     margin: auto;
     display: block;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
 }
 
 body {
@@ -15,8 +19,9 @@ body {
 .textLayer {
     position: absolute;
     text-align: initial;
-    left: 0;
-    top: 0;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     right: 0;
     bottom: 0;
     overflow: hidden;

--- a/app/src/main/assets/viewer.js
+++ b/app/src/main/assets/viewer.js
@@ -19,6 +19,14 @@ let useRender;
 const cache = [];
 const maxCached = 6;
 
+const H_PADDING_HINT = 32; // in pixels
+const V_PADDING_HINT = 32; // in pixels
+
+// This helps in preventing repetitive calculation (addition) ahead
+// Instead of adding the canvas width/height with the padding we subtract the RHS instead
+const sWWithoutPad = screen.width - H_PADDING_HINT;
+const sHWithoutPad = screen.height - V_PADDING_HINT;
+
 function maybeRenderNextPage() {
     if (renderPending) {
         pageRendering = false;
@@ -61,6 +69,63 @@ function display(newCanvas, zoom) {
     }
 }
 
+// Centers the page (i.e. canvas + text layer) vertically
+function verticallyCenterPage() {
+    canvas.style.top = "50%";
+    textLayerDiv.style.top = "50%";
+}
+
+// Centers the page (i.e. canvas + text layer) horizontally
+function horizontallyCenterPage() {
+    canvas.style.left = "50%";
+    textLayerDiv.style.left = "50%";
+}
+
+// Fixes canvas position (both horizontally and vertically)
+//
+// Center the page if it's completely visible on the screen (along with the padding)
+// else ensure that the user hasn't moved beyond the bounds and padding of the page while
+// zooming
+function fixCanvasPositioning() {
+    if (canvas.clientWidth <= sWWithoutPad) horizontallyCenterPage();
+    else ensurePageWithinHorizontalBounds();
+
+    if (canvas.clientHeight <= sHWithoutPad) verticallyCenterPage();
+    else ensurePageWithinVerticalBounds();
+}
+
+function ensurePageWithinHorizontalBounds() {
+    var pageL = canvas.offsetLeft;
+    const cWidthH = canvas.clientWidth / 2;
+
+    const x0 = cWidthH + H_PADDING_HINT;
+    const x1 = -x0 + screen.width;
+
+    if (pageL > x0) pageL = x0;
+    else if (pageL < x1) pageL = x1;
+
+    pageL += "px";
+
+    canvas.style.left = pageL;
+    textLayerDiv.style.left = pageL;
+}
+
+function ensurePageWithinVerticalBounds() {
+    var pageT = canvas.offsetTop;
+    const cHeightH = canvas.clientHeight / 2;
+
+    const y0 = cHeightH + V_PADDING_HINT;
+    const y1 = -y0 + screen.height;
+
+    if (pageT > y0) pageT = y0;
+    else if (pageT < y1) pageT = y1;
+
+    pageT += "px";
+
+    canvas.style.top = pageT;
+    textLayerDiv.style.top = pageT;
+}
+
 function renderPage(pageNumber, zoom, prerender, prerenderTrigger=0) {
     pageRendering = true;
     useRender = !prerender;
@@ -86,6 +151,7 @@ function renderPage(pageNumber, zoom, prerender, prerenderTrigger=0) {
 
             pageRendering = false;
             doPrerender(pageNumber, prerenderTrigger);
+            fixCanvasPositioning();
             return;
         }
     }
@@ -118,6 +184,7 @@ function renderPage(pageNumber, zoom, prerender, prerenderTrigger=0) {
         newCanvas.style.width = viewport.width + "px";
         const newContext = newCanvas.getContext("2d", { alpha: false });
         newContext.scale(ratio, ratio);
+        fixCanvasPositioning();
 
         task = page.render({
             canvasContext: newContext,
@@ -222,3 +289,92 @@ function loadDocument() {
         console.error(reason.name + ": " + reason.message);
     });
 }
+
+let lastX = 0;
+let lastY = 0;
+let shouldMove = false;
+
+function onTouchStart(te) {
+    if (te.touches.length == 1) {
+        shouldMove = true;
+        let t = te.touches[0];
+        lastX = t.clientX;
+        lastY = t.clientY;
+        return;
+    }
+    shouldMove = false;
+}
+
+function onTouchMove(te) {
+
+    if (!shouldMove) return;
+
+    const t = te.touches[0];
+
+    if (canvas.clientWidth > sWWithoutPad) {
+
+        const xDelta = (lastX - t.clientX);
+        var pageL = (canvas.offsetLeft - xDelta);
+
+        const cWidthH = canvas.clientWidth / 2;
+
+        const x0 = cWidthH + H_PADDING_HINT;
+        const x1 = -x0 + screen.width;
+
+        // console.log("x0: " + x0);
+        // console.log("x1: " + x1);
+
+        // console.log("old.pageL: " + pageL);
+
+        if (pageL > x0) pageL = x0;
+        else if (pageL < x1) pageL = x1;
+
+        // console.log("new.pageL: " + pageL);
+
+        pageL += "px";
+
+        canvas.style.left = pageL;
+        textLayerDiv.style.left = pageL;
+    }
+
+    if (canvas.clientHeight > sHWithoutPad) {
+
+        const yDelta = (lastY - t.clientY);
+        var pageT = (canvas.offsetTop - yDelta);
+
+        const cHeightH = canvas.clientHeight / 2;
+
+        // Calculating the top and bottom max bounds
+        const y0 = cHeightH + V_PADDING_HINT;
+        const y1 = -y0 + screen.height;
+
+        // Logging the max. vertical bounds
+        // console.log("y0: " + y0);
+        // console.log("y1: " + y1);
+
+        // Value of pageT before adjusting it w.r.t max bounds
+        // console.log("old.pageT: " + pageT);
+
+        // Adjusting the value of pageT w.r.t max bounds
+        if (pageT > y0) pageT = y0;
+        else if (pageT < y1) pageT = y1;
+
+        // Value of pageT after adjusting it w.r.t max bounds
+        // console.log("new.pageT: " + pageT);
+
+        pageT += "px";
+
+        canvas.style.top = pageT;
+        textLayerDiv.style.top = pageT;
+    }
+
+    lastX = t.clientX;
+    lastY = t.clientY;
+}
+
+function addDocumentEventListeners() {
+    document.addEventListener('touchstart', onTouchStart);
+    document.addEventListener('touchmove', onTouchMove);
+}
+
+document.addEventListener("DOMContentLoaded", addDocumentEventListeners);


### PR DESCRIPTION
A custom implementation for supporting zooming and moving across the document has been added (in commit f7b9ae7ea651cf3fa201d6001d5fe60ad73f399f) to support the changes related to centering the document.

Without the custom implementation, the user won't be able to properly move across the document, specifically the top-left corner (as the user gets restricted to the actual bounds of the page [once they have sufficiently zoomed in]).

We might require to test or review this PR before we merge these changes.