### PR TITLE
horizontally and vertically center canvas and text layer

### DIFF
--- a/app/src/main/assets/viewer.css
+++ b/app/src/main/assets/viewer.css
@@ -1,24 +1,36 @@
+html, body {
+    height: 100%;
+}
+
 body, canvas {
     padding: 0;
     margin: 0;
-}
-
-canvas {
-    margin: auto;
-    display: block;
 }
 
 body {
     background-color: #c0c0c0;
 }
 
+#container {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+}
+
+#container canvas, #container .textLayer {
+    /* overlay child elements on top of each other */
+    grid-row-start: 1;
+    grid-column-start: 1;
+}
+
+canvas, .textLayer {
+    display: inline-block;
+    position: relative;
+}
+
 .textLayer {
-    position: absolute;
     text-align: initial;
-    left: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
     overflow: hidden;
     opacity: 0.2;
     line-height: 1;

--- a/app/src/main/assets/viewer.html
+++ b/app/src/main/assets/viewer.html
@@ -7,8 +7,10 @@
         <script src="pdf.js"></script>
     </head>
     <body>
-        <canvas id="content"></canvas>
-        <div id="text" class="textLayer"></div>
+        <div id="container">
+            <canvas id="content"></canvas>
+            <div id="text" class="textLayer"></div>
+        </div>
         <script src="viewer.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Also fixes an issue where text layer is not exactly on top of the canvas when cavas width is less than screen width (which happens often in landscape mode or when fully zoomed out)