### PR TITLE
[webview] set minimum font size to 1px

### DIFF
--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
@@ -252,6 +252,7 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
         settings.setAllowFileAccess(false);
         settings.setCacheMode(WebSettings.LOAD_NO_CACHE);
         settings.setJavaScriptEnabled(true);
+        settings.setMinimumFontSize(1);
 
         CookieManager.getInstance().setAcceptCookie(false);
 


### PR DESCRIPTION
This fixes an issue where some text layer divs (those with font size < 8px) gets misaligned due to webview setting their font size to 8px.