### PR TITLE
Always shows previous and next page button in any Display size

### DIFF
--- a/app/src/main/res/menu/pdf_viewer.xml
+++ b/app/src/main/res/menu/pdf_viewer.xml
@@ -11,13 +11,13 @@
         android:id="@+id/action_previous"
         android:icon="@drawable/ic_navigate_before_24dp"
         android:title="@string/action_previous"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/action_next"
         android:icon="@drawable/ic_navigate_next_24dp"
         android:title="@string/action_next"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/action_open"


### PR DESCRIPTION
fixed #96.
I also find the app not quite usable if the next page button is hiding inside the app menu as mentioned by @ghost.

I think it is a good idea to force it always display page navigation button in the action bar, since the app do not support gesture-based navigation yet (IMO it is redundant if both page navigation button already shown in the action bar).