### PR TITLE
set zoomRatio to fit document to screen size

### DIFF
--- a/app/src/main/assets/viewer.js
+++ b/app/src/main/assets/viewer.js
@@ -72,6 +72,13 @@ function setLayerTransform(pageWidth, pageHeight, layerDiv) {
     layerDiv.style.translate = `${translate.X}px ${translate.Y}px`;
 }
 
+function getDefaultZoomRatio(page, orientationDegrees) {
+    const viewport = page.getViewport({scale: 1, rotation: orientationDegrees});
+    const widthZoomRatio = document.body.clientWidth / viewport.width;
+    const heightZoomRatio = document.body.clientHeight / viewport.height;
+    return Math.max(Math.min(widthZoomRatio, heightZoomRatio, channel.getMaxZoomRatio()), channel.getMinZoomRatio());
+}
+
 function renderPage(pageNumber, zoom, prerender, prerenderTrigger=0) {
     pageRendering = true;
     useRender = !prerender;
@@ -106,6 +113,14 @@ function renderPage(pageNumber, zoom, prerender, prerenderTrigger=0) {
     pdfDoc.getPage(pageNumber).then(function(page) {
         if (maybeRenderNextPage()) {
             return;
+        }
+
+        const defaultZoomRatio = getDefaultZoomRatio(page, orientationDegrees);
+
+        if (cache.length === 0) {
+            zoomRatio = defaultZoomRatio;
+            newZoomRatio = defaultZoomRatio;
+            channel.setZoomRatio(defaultZoomRatio);
         }
 
         const viewport = page.getViewport({scale: newZoomRatio, rotation: orientationDegrees});

--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
@@ -108,7 +108,7 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
         "usb=(), " +
         "xr-spatial-tracking=()";
 
-    private static final float MIN_ZOOM_RATIO = 0.5f;
+    private static final float MIN_ZOOM_RATIO = 0.2f;
     private static final float MAX_ZOOM_RATIO = 1.5f;
     private static final int ALPHA_LOW = 130;
     private static final int ALPHA_HIGH = 255;
@@ -170,6 +170,21 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
         @JavascriptInterface
         public float getZoomRatio() {
             return mZoomRatio;
+        }
+
+        @JavascriptInterface
+        public void setZoomRatio(final float ratio) {
+            mZoomRatio = Math.max(Math.min(ratio, MAX_ZOOM_RATIO), MIN_ZOOM_RATIO);
+        }
+
+        @JavascriptInterface
+        public float getMinZoomRatio() {
+            return MIN_ZOOM_RATIO;
+        }
+
+        @JavascriptInterface
+        public float getMaxZoomRatio() {
+            return MAX_ZOOM_RATIO;
         }
 
         @JavascriptInterface


### PR DESCRIPTION
This adjusts the zoom ratio after opening a document (or rotating) so the document fits the whole screen.
It also sets the minimum zoom ratio to the same value, because there is not really a need to zoom out further.

Closes: #184, Closes: #201 