### PR TITLE
add navigating back and forth in PDF by swiping right or left

### DIFF
--- a/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.java
@@ -7,6 +7,8 @@ import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+
 /*
     The GestureHelper present a simple gesture api for the PdfViewer
 */
@@ -14,6 +16,10 @@ import android.view.View;
 class GestureHelper {
     public interface GestureListener {
         boolean onTapUp();
+
+        void onSwipeLeft();
+        void onSwipeRight();
+
         // Can be replaced with ratio when supported
         void onZoomIn(float value);
         void onZoomOut(float value);
@@ -28,6 +34,31 @@ class GestureHelper {
                     @Override
                     public boolean onSingleTapUp(MotionEvent motionEvent) {
                         return listener.onTapUp();
+                    }
+
+                    // inspired by https://www.geeksforgeeks.org/how-to-detect-swipe-direction-in-android/
+                    @Override
+                    public boolean onFling(@NonNull MotionEvent e1, @NonNull MotionEvent e2, float velocityX, float velocityY) {
+                        final int swipeThreshold = 100;
+                        final int swipeVelocityThreshold = 100;
+
+                        final float diffX = e2.getX() - e1.getX();
+                        final float absDiffX = Math.abs(diffX);
+                        final float diffY = e2.getY() - e1.getY();
+                        final float absDiffY = Math.abs(diffY);
+
+                        if (absDiffX > absDiffY // only handle horizontal swipe
+                                && absDiffX > swipeThreshold
+                                && Math.abs(velocityX) > swipeVelocityThreshold) {
+                            if (diffX > 0) {
+                                listener.onSwipeRight();
+                            } else {
+                                listener.onSwipeLeft();
+                            }
+                            return true;
+                        }
+
+                        return false;
                     }
                 });
 

--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
@@ -211,7 +211,7 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
 
         @JavascriptInterface
         public void showPasswordPrompt() {
-            if (!getPasswordPromptFragment().isAdded()){
+            if (!getPasswordPromptFragment().isAdded()) {
                 getPasswordPromptFragment().show(getSupportFragmentManager(), PasswordPromptFragment.class.getName());
             }
             passwordValidationViewModel.passwordMissing();
@@ -360,6 +360,16 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
                             return true;
                         }
                         return false;
+                    }
+
+                    @Override
+                    public void onSwipeLeft() {
+                        onJumpToPageInDocument(mPage + 1);
+                    }
+
+                    @Override
+                    public void onSwipeRight() {
+                        onJumpToPageInDocument(mPage - 1);
                     }
 
                     @Override


### PR DESCRIPTION
Intends to implement #41 

The threshold values are a bit arbitrary but seem to be working fine on a Pixel 6 with latest GrapheneOS.

Swiping from the left or right edge will still "close" the app as it does in current version [17](https://github.com/GrapheneOS/PdfViewer/releases/tag/17).