### PR TITLE
try loading file anyways if MIME type is null, for app compatibility

### DIFF
--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
@@ -393,7 +393,8 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
 
         final Intent intent = getIntent();
         if (Intent.ACTION_VIEW.equals(intent.getAction())) {
-            if (!"application/pdf".equals(intent.getType())) {
+            final String type = intent.getType();
+            if (!"application/pdf".equals(type) && (type != null)) {
                 snackbar.setText(R.string.invalid_mime_type).show();
                 return;
             }


### PR DESCRIPTION
Some apps somehow end up giving us a pdf with a null MIME type. This makes us compatible with them instead of showing an invalid MIME type error. The error is still shown for MIME types that are not "application/pdf" and not null.

This will probably close https://github.com/GrapheneOS/PdfViewer/issues/387, but I haven't tried with the specific app reported in it. I had this issue with another app.