### PR TITLE
Replace interest-cohort with browsing-topics

### DIFF
--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
@@ -81,7 +81,8 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
         "accelerometer=(), " +
         "ambient-light-sensor=(), " +
         "autoplay=(), " +
-        "battery=(), " +
+        "battery=(), " 
+        "browsing-topics=(), " +
         "camera=(), " +
         "clipboard-read=(), " +
         "clipboard-write=(), " +
@@ -94,7 +95,6 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
         "gyroscope=(), " +
         "hid=(), " +
         "idle-detection=(), " +
-        "interest-cohort=(), " +
         "magnetometer=(), " +
         "microphone=(), " +
         "midi=(), " +


### PR DESCRIPTION
`interest-cohort` is no longer recognized by any browsers, and has been superseded by `browsing-topics`. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/browsing-topics and https://www.theverge.com/2022/1/25/22900567/google-floc-abandon-topics-api-cookies-tracking