### PR TITLE
make text selection opaque

### DIFF
--- a/viewer/css/text_layer.css
+++ b/viewer/css/text_layer.css
@@ -43,8 +43,8 @@
 }
 
 .textLayer .highlight {
-    --highlight-bg-color: rgb(180 0 170 / 0.25);
-    --highlight-selected-bg-color: rgb(0 100 0 / 0.25);
+    --highlight-bg-color: rgb(180 0 170 / 1);
+    --highlight-selected-bg-color: rgb(0 100 0 / 1);
     --highlight-backdrop-filter: none;
     --highlight-selected-backdrop-filter: none;
 }
@@ -90,8 +90,8 @@
 }
 
 .textLayer ::selection {
-    background: rgba(0 0 255 / 0.25);
-    background: color-mix(in srgb, AccentColor, transparent 75%);
+    background: rgba(0 0 255 / 1);
+    background: AccentColor;
 }
 
 .textLayer br::selection {


### PR DESCRIPTION
Temporary workaround to make selection darker until a more robust solution is identified.