### PR TITLE
Make pdf edge-to-edge and add logic to dodge window insets

### DIFF
--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
@@ -349,7 +349,7 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
             public @NonNull WindowInsetsCompat onApplyWindowInsets(
                     @NonNull View v, @NonNull WindowInsetsCompat insets) {
                  Insets allInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars()
-                         + WindowInsetsCompat.Type.displayCutout());
+                         | WindowInsetsCompat.Type.displayCutout());
                  mInsetLeft = allInsets.left;
                  mInsetRight = allInsets.right;
                  // Only set the bottom inset. The top will use the height of the app bar layout

--- a/app/src/main/res/layout/pdfviewer.xml
+++ b/app/src/main/res/layout/pdfviewer.xml
@@ -4,7 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <WebView
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fitsSystemWindows="true"
@@ -17,12 +23,6 @@
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
     </com.google.android.material.appbar.AppBarLayout>
-
-    <WebView
-        android:id="@+id/webview"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <ScrollView
         android:id="@+id/webview_alert_layout"

--- a/viewer/js/index.js
+++ b/viewer/js/index.js
@@ -275,6 +275,13 @@ function renderPage(pageNumber, zoom, prerender, prerenderTrigger = 0) {
         const newContext = newCanvas.getContext("2d", { alpha: false });
         newContext.scale(ratio, ratio);
 
+        // Add padding to the canvas to allow the page to be scrolled bellow/above any
+        // system/app ui that might be visible.
+        canvas.style.paddingLeft = (channel.getInsetLeft() / ratio) + "px";
+        canvas.style.paddingTop = (channel.getInsetTop() / ratio) + "px";
+        canvas.style.paddingRight = (channel.getInsetRight() / ratio) + "px";
+        canvas.style.paddingBottom = (channel.getInsetBottom() / ratio) + "px";
+
         task = page.render({
             canvasContext: newContext,
             viewport: newViewport

--- a/viewer/js/index.js
+++ b/viewer/js/index.js
@@ -71,9 +71,23 @@ function display(newCanvas, zoom) {
 }
 
 function setLayerTransform(pageWidth, pageHeight, layerDiv) {
+    const cs = globalThis.getComputedStyle(canvas);
+    const insetLeft = parseFloat(cs.paddingLeft) || 0;
+    const insetTop = parseFloat(cs.paddingTop) || 0;
+    const insetRight = parseFloat(cs.paddingRight) || 0;
+    const insetBottom = parseFloat(cs.paddingBottom) || 0;
+
+    const isOverflownY = canvas.clientHeight > document.body.clientHeight;
+    const isOverflownX = canvas.clientWidth > document.body.clientWidth;
+    // Translate the text layer to stay aligned with the rendered page including canvas insets and
+    // grid centering effects.
     const translate = {
-        X: Math.max(0, pageWidth - document.body.clientWidth) / 2,
-        Y: Math.max(0, pageHeight - document.body.clientHeight) / 2
+        X: isOverflownX
+            ? insetLeft - (document.body.clientWidth - pageWidth) / 2
+            : (insetLeft - insetRight) / 2,
+        Y: isOverflownY
+            ? insetTop - (document.body.clientHeight - pageHeight) / 2
+            : (insetTop - insetBottom) / 2
     };
     layerDiv.style.translate = `${translate.X}px ${translate.Y}px`;
 }


### PR DESCRIPTION
👋 This change makes the PDF WebView always edge-to-edge, avoiding any jumps in the pdf's location on screen when hiding/showing system insets or app UI.

Resolves https://github.com/GrapheneOS/PdfViewer/issues/273. 
The AppBarLayout's show/hide animation could still be improved if that's something the project would like!

Summary:
* Draw PDF WebView under AppBarLayout by removing the scrolling behavior and correcting z-order
* Enable edge-to-edge with `WindowCompat#enableEdgeToEdge(window)` to make WebView draw behind insets. `enableEdgeToEdge` internally calls `WindowCompat#setDecorFitsSystemWindows(window, false)` which can be removed
* Add PDF canvas insetting based on system WindowInsets and the height of the AppBarLayout so all parts of a PDF can be scrolled into view regardless of system/app UI visibility

Before: 

https://github.com/user-attachments/assets/72692fe3-5fad-4019-a0e0-eafc7cbb1431

After:

https://github.com/user-attachments/assets/ce681f4f-b27a-424b-80e3-0e56e6ae1877

https://github.com/user-attachments/assets/fee8c5b4-41ac-4a63-9daf-399590653677
