### PR TITLE
Allow jumping to previous/next page with horizontal swipe gesture

### DIFF
--- a/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.java
@@ -7,6 +7,11 @@ import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /*
     The GestureHelper present a simple gesture api for the PdfViewer
 */
@@ -14,6 +19,7 @@ import android.view.View;
 class GestureHelper {
     public interface GestureListener {
         boolean onTapUp();
+        boolean onFling(@Nullable MotionEvent e1, @NonNull MotionEvent e2, float velocityX, float velocityY);
         void onZoom(float scaleFactor, float focusX, float focusY);
         void onZoomEnd();
     }
@@ -21,18 +27,12 @@ class GestureHelper {
     @SuppressLint("ClickableViewAccessibility")
     static void attach(Context context, View gestureView, GestureListener listener) {
 
-        final GestureDetector detector = new GestureDetector(context,
-                new GestureDetector.SimpleOnGestureListener() {
-                    @Override
-                    public boolean onSingleTapUp(MotionEvent motionEvent) {
-                        return listener.onTapUp();
-                    }
-                });
+        AtomicBoolean wasScaling = new AtomicBoolean(false);
 
         final ScaleGestureDetector scaleDetector = new ScaleGestureDetector(context,
                 new ScaleGestureDetector.SimpleOnScaleGestureListener() {
                     @Override
-                    public boolean onScale(ScaleGestureDetector detector) {
+                    public boolean onScale(@NonNull ScaleGestureDetector detector) {
                         listener.onZoom(detector.getScaleFactor(), detector.getFocusX(),
                                 detector.getFocusY());
 
@@ -40,14 +40,44 @@ class GestureHelper {
                     }
 
                     @Override
-                    public void onScaleEnd(ScaleGestureDetector detector) {
+                    public void onScaleEnd(@NonNull ScaleGestureDetector detector) {
                         listener.onZoomEnd();
                     }
                 });
 
+        final GestureDetector detector = new GestureDetector(context,
+                new GestureDetector.SimpleOnGestureListener() {
+                    @Override
+                    public boolean onSingleTapUp(@NonNull MotionEvent motionEvent) {
+                        return listener.onTapUp();
+                    }
+
+                    @Override
+                    public boolean onFling(@Nullable MotionEvent e1, @NonNull MotionEvent e2,
+                                           float velocityX, float velocityY) {
+                        if (wasScaling.get()) {
+                            return false;
+                        }
+
+                        return listener.onFling(e1, e2, velocityX, velocityY);
+                    }
+                });
+
         gestureView.setOnTouchListener((view, motionEvent) -> {
+            int action = motionEvent.getActionMasked();
+
+            if (action == MotionEvent.ACTION_DOWN) {
+                wasScaling.set(false);
+            }
+
             detector.onTouchEvent(motionEvent);
             scaleDetector.onTouchEvent(motionEvent);
+
+            // Check after scaleDetector processes the event
+            if (scaleDetector.isInProgress()) {
+                wasScaling.set(true);
+            }
+
             return false;
         });
     }

--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
@@ -13,7 +13,9 @@ import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.webkit.CookieManager;
 import android.webkit.JavascriptInterface;
 import android.webkit.RenderProcessGoneDetail;
@@ -29,6 +31,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.WindowCompat;
 import androidx.fragment.app.Fragment;
@@ -128,6 +131,8 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
     private float mZoomRatio = 1f;
     private float mZoomFocusX = 0f;
     private float mZoomFocusY = 0f;
+    private int mSwipeThreshold;
+    private int mSwipeVelocityThreshold;
     private int mDocumentOrientationDegrees;
     private int mDocumentState;
     private String mEncryptedDocumentPassword;
@@ -444,6 +449,8 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
             }
         });
 
+        initializeGestures();
+
         GestureHelper.attach(PdfViewer.this, binding.webview,
                 new GestureHelper.GestureListener() {
                     @Override
@@ -460,6 +467,39 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
                             });
                             return true;
                         }
+                        return false;
+                    }
+
+                    @Override
+                    public boolean onFling(@Nullable MotionEvent e1, @NonNull MotionEvent e2, float velocityX, float velocityY) {
+                        if (e1 == null) return false;
+
+                        float deltaX = e2.getX() - e1.getX();
+                        float deltaY = e2.getY() - e1.getY();
+                        float absDeltaX = Math.abs(deltaX);
+                        float absDeltaY = Math.abs(deltaY);
+
+                        // Check primarily horizontal
+                        if (absDeltaX > absDeltaY &&
+                                absDeltaX > mSwipeThreshold &&
+                                Math.abs(velocityX) > mSwipeVelocityThreshold) {
+
+                            boolean swipeLeft = deltaX < 0;
+                            boolean swipeRight = deltaX > 0;
+
+                            // Edge detection
+                            boolean atLeftEdge = !binding.webview.canScrollHorizontally(-1);
+                            boolean atRightEdge = !binding.webview.canScrollHorizontally(1);
+
+                            if (swipeLeft && atRightEdge) {
+                                onJumpToPageInDocument(mPage + 1);
+                                return true;
+                            } else if (swipeRight && atLeftEdge) {
+                                onJumpToPageInDocument(mPage - 1);
+                                return true;
+                            }
+                        }
+
                         return false;
                     }
 
@@ -531,6 +571,12 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
 
             loadPdf();
         }
+    }
+
+    private void initializeGestures() {
+        ViewConfiguration vc = ViewConfiguration.get(this);
+        mSwipeThreshold = vc.getScaledTouchSlop() * 6;
+        mSwipeVelocityThreshold = vc.getScaledMinimumFlingVelocity();
     }
 
     private void purgeWebView() {


### PR DESCRIPTION
This is an improved version of #383, which lacks edge detection, in which case page will change regardless if we are in the middle of a page or at its edge.

The swipe is horizontal only.

closes #41.