### PR TITLE
fix Utils.parseDate dropping optional trailing date fields

### DIFF
--- a/app/src/main/java/app/grapheneos/pdfviewer/Utils.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/Utils.java
@@ -54,7 +54,7 @@ public class Utils {
         int seconds = 0;
 
         // All succeeding fields are optional, but each preceding field must be present
-        if (date.length() > 8) {
+        if (date.length() >= 8) {
             field = date.substring(position, 8);
             if (!TextUtils.isDigitsOnly(field)) {
                 throw new ParseException("Invalid month", position);
@@ -65,7 +65,7 @@ public class Utils {
             }
             position += 2;
         }
-        if (date.length() > 10) {
+        if (date.length() >= 10) {
             field = date.substring(8, 10);
             if (!TextUtils.isDigitsOnly(field)) {
                 throw new ParseException("Invalid day", position);
@@ -76,7 +76,7 @@ public class Utils {
             }
             position += 2;
         }
-        if (date.length() > 12) {
+        if (date.length() >= 12) {
             field = date.substring(10, 12);
             if (!TextUtils.isDigitsOnly(field)) {
                 throw new ParseException("Invalid hours", position);
@@ -87,7 +87,7 @@ public class Utils {
             }
             position += 2;
         }
-        if (date.length() > 14) {
+        if (date.length() >= 14) {
             field = date.substring(12, 14);
             if (!TextUtils.isDigitsOnly(field)) {
                 throw new ParseException("Invalid minutes", position);
@@ -98,7 +98,7 @@ public class Utils {
             }
             position += 2;
         }
-        if (date.length() > 16) {
+        if (date.length() >= 16) {
             field = date.substring(14, 16);
             if (!TextUtils.isDigitsOnly(field)) {
                 throw new ParseException("Invalid seconds", position);


### PR DESCRIPTION
Each optional field in a PDF date string (PDF 1.7 §7.9.4) ends at an absolute index `N` month=8, day=10, hours=12, minutes=14, seconds=16. Reading such a field only needs `date.length() >= N`, but the guards used `> N`, so any date ending exactly on a field boundary was skipped and then mis-parsed as the UT relation, throwing `ParseException` and surfacing as the "invalid date" fallback in the Document Properties dialog.

Example: `D:20250115` (year+month+day, length 10) skipped the day, left `position` at 8, then tried to read `'0'` as `+`/`-`/`Z` and failed.

Fix: change the five length gates from `> N` to `>= N`. The trailing UT-relation gate is left as `>` since it requires at least one additional sign character. No behavioural change for dates that previously parsed, `length > N` implies `length >= N`.