### PR TITLE
Fix document name extraction from document properties

### DIFF
--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
@@ -53,10 +53,11 @@ import app.grapheneos.pdfviewer.fragment.JumpToPageFragment;
 import app.grapheneos.pdfviewer.fragment.PasswordPromptFragment;
 import app.grapheneos.pdfviewer.ktx.ViewKt;
 import app.grapheneos.pdfviewer.loader.DocumentPropertiesAsyncTaskLoader;
+import app.grapheneos.pdfviewer.loader.DocumentPropertiesResult;
 import app.grapheneos.pdfviewer.outline.OutlineFragment;
 import app.grapheneos.pdfviewer.viewModel.PdfViewModel;
 
-public class PdfViewer extends AppCompatActivity implements LoaderManager.LoaderCallbacks<List<CharSequence>> {
+public class PdfViewer extends AppCompatActivity implements LoaderManager.LoaderCallbacks<DocumentPropertiesResult> {
     private static final String TAG = "PdfViewer";
 
     private static final String STATE_WEBVIEW_CRASHED = "webview_crashed";
@@ -129,6 +130,7 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
     private int mDocumentState;
     private String mEncryptedDocumentPassword;
     private List<CharSequence> mDocumentProperties;
+    private String mDocumentName;
     private InputStream mInputStream;
 
     private PdfviewerBinding binding;
@@ -147,6 +149,7 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
                     mUri = result.getData().getData();
                     mPage = 1;
                     mDocumentProperties = null;
+                    mDocumentName = null;
                     mEncryptedDocumentPassword = "";
                     viewModel.clearOutline();
                     loadPdf();
@@ -592,21 +595,28 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
 
     @NonNull
     @Override
-    public Loader<List<CharSequence>> onCreateLoader(int id, Bundle args) {
+    public Loader<DocumentPropertiesResult> onCreateLoader(int id, Bundle args) {
         return new DocumentPropertiesAsyncTaskLoader(this, args.getString(KEY_PROPERTIES), mNumPages, mUri);
     }
 
     @Override
-    public void onLoadFinished(@NonNull Loader<List<CharSequence>> loader, List<CharSequence> data) {
-        mDocumentProperties = data;
+    public void onLoadFinished(@NonNull Loader<DocumentPropertiesResult> loader, DocumentPropertiesResult data) {
+        if (data != null) {
+            mDocumentProperties = data.getList();
+            mDocumentName = data.getDocumentName();
+        } else {
+            mDocumentProperties = null;
+            mDocumentName = null;
+        }
         invalidateOptionsMenu();
         setToolbarTitleWithDocumentName();
         LoaderManager.getInstance(this).destroyLoader(DocumentPropertiesAsyncTaskLoader.ID);
     }
 
     @Override
-    public void onLoaderReset(@NonNull Loader<List<CharSequence>> loader) {
+    public void onLoaderReset(@NonNull Loader<DocumentPropertiesResult> loader) {
         mDocumentProperties = null;
+        mDocumentName = null;
     }
 
     private void loadPdf() {
@@ -841,18 +851,7 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
     }
 
     private String getCurrentDocumentName() {
-        if (mDocumentProperties == null || mDocumentProperties.isEmpty()) return "";
-        String fileName = "";
-        String title = "";
-        for (CharSequence property : mDocumentProperties) {
-            if (property.toString().startsWith("File name:")) {
-                fileName = property.toString().replace("File name:", "");
-            }
-            if (property.toString().startsWith("Title:-")) {
-                title = property.toString().replace("Title:-", "");
-            }
-        }
-        return fileName.length() > 2 ? fileName : title;
+        return mDocumentName != null ? mDocumentName : "";
     }
 
     private void saveDocumentAs(final Uri uri) {

--- a/app/src/main/java/app/grapheneos/pdfviewer/loader/DocumentPropertiesAsyncTaskLoader.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/loader/DocumentPropertiesAsyncTaskLoader.java
@@ -6,9 +6,7 @@ import android.net.Uri;
 import androidx.annotation.Nullable;
 import androidx.loader.content.AsyncTaskLoader;
 
-import java.util.List;
-
-public class DocumentPropertiesAsyncTaskLoader extends AsyncTaskLoader<List<CharSequence>> {
+public class DocumentPropertiesAsyncTaskLoader extends AsyncTaskLoader<DocumentPropertiesResult> {
 
     public static final String TAG = "DocumentPropertiesLoader";
 
@@ -34,7 +32,7 @@ public class DocumentPropertiesAsyncTaskLoader extends AsyncTaskLoader<List<Char
 
     @Nullable
     @Override
-    public List<CharSequence> loadInBackground() {
+    public DocumentPropertiesResult loadInBackground() {
 
         DocumentPropertiesLoader loader = new DocumentPropertiesLoader(
                 getContext(),
@@ -43,6 +41,6 @@ public class DocumentPropertiesAsyncTaskLoader extends AsyncTaskLoader<List<Char
                 mUri
         );
 
-        return loader.loadAsList();
+        return loader.loadAsResult();
     }
 }

--- a/app/src/main/java/app/grapheneos/pdfviewer/loader/DocumentPropertiesLoader.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/loader/DocumentPropertiesLoader.kt
@@ -20,8 +20,9 @@ class DocumentPropertiesLoader(
     private val mUri: Uri
 ) {
 
-    fun loadAsList(): List<CharSequence> {
-        return load().map { item ->
+    fun loadAsResult(): DocumentPropertiesResult {
+        val raw = load()
+        val list = raw.map { item ->
             val name = context.getString(item.key.nameResource)
             val value = item.value
 
@@ -38,6 +39,19 @@ class DocumentPropertiesLoader(
                     )
                 }
         }
+        return DocumentPropertiesResult(list = list, documentName = resolveDocumentName(raw))
+    }
+
+    private fun resolveDocumentName(raw: Map<DocumentProperty, String>): String {
+        val fileName = raw[DocumentProperty.FileName].orEmpty()
+        if (fileName.isNotEmpty() && fileName != DEFAULT_VALUE) {
+            return fileName
+        }
+        val title = raw[DocumentProperty.Title].orEmpty()
+        if (title.isNotEmpty() && title != DEFAULT_VALUE) {
+            return title
+        }
+        return ""
     }
 
     private fun load(): Map<DocumentProperty, String> {

--- a/app/src/main/java/app/grapheneos/pdfviewer/loader/DocumentPropertiesResult.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/loader/DocumentPropertiesResult.kt
@@ -1,0 +1,12 @@
+package app.grapheneos.pdfviewer.loader
+
+/**
+ * Holds the output of [DocumentPropertiesLoader]:
+ * - [list]: pre-formatted, localized strings used by the document properties dialog.
+ * - [documentName]: the document name resolved from raw, non-localized values
+ *   (file name, falling back to the PDF title). Empty if neither is available.
+ */
+data class DocumentPropertiesResult(
+    val list: List<CharSequence>,
+    val documentName: String,
+)


### PR DESCRIPTION
This PR fixes `getCurrentDocumentName()` in PdfViewer.java, which produced wrong or empty document names (used for the toolbar title and the Save-As default filename).

### What was wrong
- It parsed the *formatted, localized* strings shown in the Document Properties dialog (`"File name:\n…"`, `"Title:\n…"`). The labels come from `R.string.file_name` / `R.string.title` in `DocumentPropertiesLoader`, so any future translation would silently break it.
- On top of that, the original prefixes were also wrong: `"File name:"` was missing the trailing newline so `replace()` left a leading `\n` in the result, and `"Title:-"` never matched anything, so the title fallback was dead code.
- The filename selection used a brittle `length > 2` check that could reject valid short filenames.

## What this changes
- Resolves the document name directly from the raw `Map<DocumentProperty, String>` produced by `DocumentPropertiesLoader`, using the stable enum keys `DocumentProperty.FileName` (falling back to `DocumentProperty.Title` when its value isn't `DEFAULT_VALUE`). No string parsing of localized output.
- `DocumentPropertiesLoader` now returns a `DocumentPropertiesResult` carrying both the formatted `List<CharSequence>` used by the existing dialog and the pre-resolved `documentName`. The dialog UI is unchanged.
- `PdfViewer` caches the resolved name in a new `mDocumentName` field; `getCurrentDocumentName()` becomes a trivial accessor. The field is reset alongside `mDocumentProperties` on document change and loader reset.

Net effect: name resolution is fully decoupled from UI strings, so future translations of the property labels won't break the toolbar/Save-As behavior.
