### PR TITLE
Add error feedback for load failures; Reset all document state on load

### DIFF
--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewer.java
@@ -147,11 +147,7 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
                 Intent resultData = result.getData();
                 if (resultData != null) {
                     mUri = result.getData().getData();
-                    mPage = 1;
-                    mDocumentProperties = null;
-                    mDocumentName = null;
-                    mEncryptedDocumentPassword = "";
-                    viewModel.clearOutline();
+                    resetDocumentState();
                     loadPdf();
                     invalidateOptionsMenu();
                 }
@@ -262,6 +258,16 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
             if (getPasswordPromptFragment().isAdded()) {
                 getPasswordPromptFragment().dismiss();
             }
+        }
+
+        @JavascriptInterface
+        public void onLoadError() {
+            runOnUiThread(() -> {
+                maybeCloseInputStream();
+                resetDocumentState();
+                invalidateOptionsMenu();
+                snackbar.setText(R.string.error_while_opening).show();
+            });
         }
 
         @JavascriptInterface
@@ -873,5 +879,17 @@ public class PdfViewer extends AppCompatActivity implements LoaderManager.Loader
                 SecurityException e) {
             snackbar.setText(R.string.error_while_saving).show();
         }
+    }
+
+    private void resetDocumentState() {
+        mPage = 1;
+        mNumPages = 0;
+        mZoomRatio = 1f;
+        mDocumentOrientationDegrees = 0;
+        mDocumentProperties = null;
+        mDocumentName = null;
+        mEncryptedDocumentPassword = "";
+        mDocumentState = 0;
+        viewModel.clearOutline();
     }
 }

--- a/viewer/js/index.js
+++ b/viewer/js/index.js
@@ -434,6 +434,7 @@ globalThis.loadDocument = function () {
         renderPage(channel.getPage(), false, false);
     }, function (reason) {
         console.error(reason.name + ": " + reason.message);
+        channel.onLoadError();
     });
 };
 


### PR DESCRIPTION
When pdf.js fails to load a document, the Android side is not notified, leaving the UI in a broken state.

Add a handler to JS and resets document state on Android side. Also fixes rotation and zoom not resetting when opening a new document.

Fixes #635
Fixes #636