### PR TITLE
improve desktop mode and swipe UX + use the recommended pdf.js canvas rendering API 

### DIFF
--- a/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/test/PdfViewerNavigationTest.kt
+++ b/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/test/PdfViewerNavigationTest.kt
@@ -127,6 +127,36 @@ class PdfViewerNavigationTest {
     }
 
     @Test
+    fun mouseSwipeLeft_doesNotGoToNextPage() {
+        PdfViewerLauncher.launchWithTestAsset("test-multipage.pdf").use { scenario ->
+            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
+            PdfViewerTestUtils.waitForCanvasRendered(scenario)
+            setupNavigableState(scenario, page = 2)
+
+            robot.performMouseSwipe(scenario, left = true)
+
+            scenario.onActivity {
+                assertEquals(2, it.currentPage)
+            }
+        }
+    }
+
+    @Test
+    fun touchSwipeLeft_goesToNextPage() {
+        PdfViewerLauncher.launchWithTestAsset("test-multipage.pdf").use { scenario ->
+            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
+            PdfViewerTestUtils.waitForCanvasRendered(scenario)
+            setupNavigableState(scenario, page = 2)
+
+            robot.performTouchSwipe(scenario, left = true)
+
+            scenario.onActivity {
+                assertEquals(3, it.currentPage)
+            }
+        }
+    }
+
+    @Test
     fun tapNext_updatesMenuState() {
         PdfViewerLauncher.launchWithTestAsset("test-multipage.pdf").use { scenario ->
             PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)

--- a/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/test/PdfViewerNavigationTest.kt
+++ b/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/test/PdfViewerNavigationTest.kt
@@ -97,6 +97,36 @@ class PdfViewerNavigationTest {
     }
 
     @Test
+    fun keyboardRightArrow_goesToNextPage() {
+        PdfViewerLauncher.launchWithTestAsset("test-multipage.pdf").use { scenario ->
+            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
+            PdfViewerTestUtils.waitForCanvasRendered(scenario)
+            setupNavigableState(scenario, page = 2)
+
+            robot.pressKeyboardArrow(scenario, PdfViewerRobot.KeyboardArrow.Right)
+
+            scenario.onActivity {
+                assertEquals(3, it.currentPage)
+            }
+        }
+    }
+
+    @Test
+    fun keyboardLeftArrow_goesToPreviousPage() {
+        PdfViewerLauncher.launchWithTestAsset("test-multipage.pdf").use { scenario ->
+            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
+            PdfViewerTestUtils.waitForCanvasRendered(scenario)
+            setupNavigableState(scenario, page = 3)
+
+            robot.pressKeyboardArrow(scenario, PdfViewerRobot.KeyboardArrow.Left)
+
+            scenario.onActivity {
+                assertEquals(2, it.currentPage)
+            }
+        }
+    }
+
+    @Test
     fun tapNext_updatesMenuState() {
         PdfViewerLauncher.launchWithTestAsset("test-multipage.pdf").use { scenario ->
             PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)

--- a/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/test/PdfViewerNavigationTest.kt
+++ b/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/test/PdfViewerNavigationTest.kt
@@ -142,7 +142,7 @@ class PdfViewerNavigationTest {
     }
 
     @Test
-    fun touchSwipeLeft_goesToNextPage() {
+    fun touchSwipeLeft_withSlowRelease_goesToNextPage() {
         PdfViewerLauncher.launchWithTestAsset("test-multipage.pdf").use { scenario ->
             PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
             PdfViewerTestUtils.waitForCanvasRendered(scenario)
@@ -152,6 +152,21 @@ class PdfViewerNavigationTest {
 
             scenario.onActivity {
                 assertEquals(3, it.currentPage)
+            }
+        }
+    }
+
+    @Test
+    fun touchSwipeRight_withSlowRelease_goesToPreviousPage() {
+        PdfViewerLauncher.launchWithTestAsset("test-multipage.pdf").use { scenario ->
+            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
+            PdfViewerTestUtils.waitForCanvasRendered(scenario)
+            setupNavigableState(scenario, page = 3)
+
+            robot.performTouchSwipe(scenario, left = false)
+
+            scenario.onActivity {
+                assertEquals(2, it.currentPage)
             }
         }
     }

--- a/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/test/PdfViewerRenderTest.kt
+++ b/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/test/PdfViewerRenderTest.kt
@@ -98,6 +98,29 @@ class PdfViewerRenderTest {
     }
 
     @Test
+    fun setZoomRatio_clampsToMinimumZoomRatio() {
+        PdfViewerLauncher.launchWithTestAsset("test-simple.pdf").use { scenario ->
+            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
+            PdfViewerTestUtils.waitForCanvasRendered(scenario)
+
+            val clampedZoom = PdfViewerTestUtils.evaluateJs(
+                scenario,
+                """
+                    (function() {
+                        channel.setZoomRatio(-1);
+                        return channel.getZoomRatio();
+                    })()
+                """.trimIndent()
+            ).toFloat()
+
+            assertTrue(
+                "Zoom ratio did not clamp to MIN_ZOOM_RATIO (was $clampedZoom)",
+                abs(clampedZoom - MIN_ZOOM_RATIO) < 0.001f
+            )
+        }
+    }
+
+    @Test
     fun rotation_changesCanvasOrientationAndPreservesTextLayer() {
         PdfViewerLauncher.launchWithTestAsset("test-simple.pdf").use { scenario ->
             PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
@@ -140,138 +163,6 @@ class PdfViewerRenderTest {
             )
             PdfViewerTestUtils.assertTextLayerContent(scenario, "Test Text")
             robot.assertTextLayerAligned(scenario)
-        }
-    }
-
-    @Test
-    fun zoomIn_increasesDimensionsAndPreservesTextLayer() {
-        PdfViewerLauncher.launchWithTestAsset("test-simple.pdf").use { scenario ->
-            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
-            PdfViewerTestUtils.waitForCanvasRendered(scenario)
-            PdfViewerTestUtils.assertTextLayerContent(scenario, "Test Text")
-
-            val initialWidth = robot.getCanvasCssWidth(scenario)
-            val initialHeight = robot.getCanvasCssHeight(scenario)
-
-            robot.performPinchZoomIn(scenario)
-
-            PdfViewerTestUtils.waitForCanvasCssDimensionsChanged(
-                scenario, initialWidth, initialHeight
-            )
-
-            val zoomedWidth = robot.getCanvasCssWidth(scenario)
-            val zoomedHeight = robot.getCanvasCssHeight(scenario)
-            assertTrue(
-                "Canvas CSS width should increase after zoom in " +
-                        "($initialWidth → $zoomedWidth)",
-                zoomedWidth > initialWidth
-            )
-            assertTrue(
-                "Canvas CSS height should increase after zoom in " +
-                        "($initialHeight → $zoomedHeight)",
-                zoomedHeight > initialHeight
-            )
-
-            PdfViewerTestUtils.assertTextLayerContent(scenario, "Test Text")
-            robot.assertTextLayerAligned(scenario)
-        }
-    }
-
-    @Test
-    fun zoomOut_decreasesDimensionsAndPreservesTextLayer() {
-        PdfViewerLauncher.launchWithTestAsset("test-simple.pdf").use { scenario ->
-            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
-            PdfViewerTestUtils.waitForCanvasRendered(scenario)
-
-            val defaultWidth = robot.getCanvasCssWidth(scenario)
-            val defaultHeight = robot.getCanvasCssHeight(scenario)
-
-            robot.performPinchZoomIn(scenario)
-            PdfViewerTestUtils.waitForCanvasCssDimensionsChanged(
-                scenario, defaultWidth, defaultHeight
-            )
-            PdfViewerTestUtils.assertTextLayerContent(scenario, "Test Text")
-            robot.assertTextLayerAligned(scenario)
-
-            val initialWidth = robot.getCanvasCssWidth(scenario)
-            val initialHeight = robot.getCanvasCssHeight(scenario)
-            val initialZoomRatio = robot.getZoomRatio(scenario)
-
-            robot.performPinchZoomOut(scenario)
-            PdfViewerTestUtils.pollUntil(
-                timeout = 15_000,
-                description = {
-                    "Zoom ratio should decrease after zoom out " +
-                            "(initial=$initialZoomRatio, current=${robot.getZoomRatio(scenario)})"
-                }
-            ) {
-                robot.getZoomRatio(scenario) < initialZoomRatio
-            }
-
-            PdfViewerTestUtils.waitForCanvasCssDimensionsChanged(
-                scenario, initialWidth, initialHeight
-            )
-
-            val zoomedWidth = robot.getCanvasCssWidth(scenario)
-            val zoomedHeight = robot.getCanvasCssHeight(scenario)
-            assertTrue(
-                "Canvas CSS width should decrease after zoom out " +
-                        "($initialWidth → $zoomedWidth)",
-                zoomedWidth < initialWidth
-            )
-            assertTrue(
-                "Canvas CSS height should decrease after zoom out " +
-                        "($initialHeight → $zoomedHeight)",
-                zoomedHeight < initialHeight
-            )
-
-            PdfViewerTestUtils.waitForCanvasRendered(scenario)
-            PdfViewerTestUtils.assertTextLayerContent(scenario, "Test Text")
-            robot.assertTextLayerAligned(scenario)
-        }
-    }
-
-    @Test
-    fun zoomOut_clampsToMinimumZoomRatio() {
-        PdfViewerLauncher.launchWithTestAsset("test-simple.pdf").use { scenario ->
-            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
-            PdfViewerTestUtils.waitForCanvasRendered(scenario)
-
-            repeat(5) { robot.performPinchZoomOut(scenario, speed = 1500) }
-
-            PdfViewerTestUtils.pollUntil(
-                timeout = 15_000,
-                description = {
-                    "Zoom ratio did not clamp to MIN_ZOOM_RATIO " +
-                            "(was ${robot.getZoomRatio(scenario)})"
-                }
-            ) {
-                abs(robot.getZoomRatio(scenario) - MIN_ZOOM_RATIO) < 0.001f
-            }
-        }
-    }
-
-    @Test
-    fun setZoomRatio_clampsToMinimumZoomRatio() {
-        PdfViewerLauncher.launchWithTestAsset("test-simple.pdf").use { scenario ->
-            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
-            PdfViewerTestUtils.waitForCanvasRendered(scenario)
-
-            val clampedZoom = PdfViewerTestUtils.evaluateJs(
-                scenario,
-                """
-                    (function() {
-                        channel.setZoomRatio(-1);
-                        return channel.getZoomRatio();
-                    })()
-                """.trimIndent()
-            ).toFloat()
-
-            assertTrue(
-                "Zoom ratio did not clamp to MIN_ZOOM_RATIO " +
-                        "(was $clampedZoom)",
-                abs(clampedZoom - MIN_ZOOM_RATIO) < 0.001f
-            )
         }
     }
 

--- a/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/test/PdfViewerZoomTest.kt
+++ b/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/test/PdfViewerZoomTest.kt
@@ -1,0 +1,259 @@
+package app.grapheneos.pdfviewer.test
+
+import androidx.test.core.app.ActivityScenario
+import app.grapheneos.pdfviewer.PdfJsChannel.Companion.MIN_ZOOM_RATIO
+import app.grapheneos.pdfviewer.PdfViewer
+import app.grapheneos.pdfviewer.RetryableComposeRule
+import app.grapheneos.pdfviewer.testrules.OrientationRules
+import app.grapheneos.pdfviewer.testrules.RetryRules
+import app.grapheneos.pdfviewer.util.PdfViewerLauncher
+import app.grapheneos.pdfviewer.util.PdfViewerRobot
+import app.grapheneos.pdfviewer.util.PdfViewerTestUtils
+import kotlin.math.abs
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+/**
+ * Shared zoom behavior across supported input methods.
+ */
+@RunWith(Parameterized::class)
+class PdfViewerZoomTest(private val zoomInput: ZoomInput) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun parameters(): List<Array<Any>> = ZoomInput.entries.map { arrayOf(it) }
+    }
+
+    enum class ZoomInput(private val displayName: String) {
+        TOUCH("touch") {
+            override fun zoomIn(robot: PdfViewerRobot, scenario: ActivityScenario<PdfViewer>) {
+                robot.performPinchZoomIn(scenario)
+            }
+
+            override fun zoomOut(robot: PdfViewerRobot, scenario: ActivityScenario<PdfViewer>) {
+                robot.performPinchZoomOut(scenario)
+            }
+
+            override fun zoomOutUntilClamp(
+                robot: PdfViewerRobot,
+                scenario: ActivityScenario<PdfViewer>
+            ) {
+                repeat(5) {
+                    robot.performPinchZoomOut(scenario, speed = 1500)
+                }
+            }
+        },
+
+        CTRL_MOUSE_WHEEL("ctrl_mouse_wheel") {
+            override fun zoomIn(robot: PdfViewerRobot, scenario: ActivityScenario<PdfViewer>) {
+                robot.performCtrlMouseWheelZoom(scenario, zoomIn = true)
+            }
+
+            override fun zoomOut(robot: PdfViewerRobot, scenario: ActivityScenario<PdfViewer>) {
+                robot.performCtrlMouseWheelZoom(scenario, zoomIn = false)
+            }
+        };
+
+        abstract fun zoomIn(robot: PdfViewerRobot, scenario: ActivityScenario<PdfViewer>)
+
+        abstract fun zoomOut(robot: PdfViewerRobot, scenario: ActivityScenario<PdfViewer>)
+
+        open fun zoomOutUntilClamp(
+            robot: PdfViewerRobot,
+            scenario: ActivityScenario<PdfViewer>
+        ) {
+            repeat(16) {
+                zoomOut(robot, scenario)
+            }
+        }
+
+        override fun toString(): String = displayName
+    }
+
+    private val composeRule = RetryableComposeRule()
+
+    @get:Rule
+    val rules: RuleChain = RuleChain
+        .outerRule(RetryRules())
+        .around(OrientationRules())
+        .around(composeRule)
+
+    private val robot = PdfViewerRobot(composeRule)
+
+    @Before
+    fun setup() {
+        PdfViewerTestUtils.init(composeRule)
+    }
+
+    @Test
+    fun zoomIn_increasesDimensionsAndPreservesTextLayer() {
+        PdfViewerLauncher.launchWithTestAsset("test-simple.pdf").use { scenario ->
+            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
+            PdfViewerTestUtils.waitForCanvasRendered(scenario)
+            PdfViewerTestUtils.assertTextLayerContent(scenario, "Test Text")
+
+            val initialWidth = robot.getCanvasCssWidth(scenario)
+            val initialHeight = robot.getCanvasCssHeight(scenario)
+            val initialZoomRatio = robot.getZoomRatio(scenario)
+
+            zoomInput.zoomIn(robot, scenario)
+
+            waitForZoomRatioAbove(scenario, initialZoomRatio, "$zoomInput zoom in")
+            PdfViewerTestUtils.waitForCanvasCssDimensionsChanged(
+                scenario,
+                initialWidth,
+                initialHeight
+            )
+
+            assertCanvasCssDimensionsIncreased(
+                scenario,
+                initialWidth,
+                initialHeight,
+                "$zoomInput zoom in"
+            )
+            assertTextLayerStillRendered(scenario)
+        }
+    }
+
+    @Test
+    fun zoomOut_decreasesDimensionsAndPreservesTextLayer() {
+        PdfViewerLauncher.launchWithTestAsset("test-simple.pdf").use { scenario ->
+            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
+            PdfViewerTestUtils.waitForCanvasRendered(scenario)
+
+            val defaultWidth = robot.getCanvasCssWidth(scenario)
+            val defaultHeight = robot.getCanvasCssHeight(scenario)
+            val defaultZoomRatio = robot.getZoomRatio(scenario)
+
+            zoomInput.zoomIn(robot, scenario)
+            waitForZoomRatioAbove(scenario, defaultZoomRatio, "$zoomInput setup zoom in")
+            PdfViewerTestUtils.waitForCanvasCssDimensionsChanged(
+                scenario,
+                defaultWidth,
+                defaultHeight
+            )
+            assertTextLayerStillRendered(scenario)
+
+            val initialWidth = robot.getCanvasCssWidth(scenario)
+            val initialHeight = robot.getCanvasCssHeight(scenario)
+            val initialZoomRatio = robot.getZoomRatio(scenario)
+
+            zoomInput.zoomOut(robot, scenario)
+
+            waitForZoomRatioBelow(scenario, initialZoomRatio, "$zoomInput zoom out")
+            PdfViewerTestUtils.waitForCanvasCssDimensionsChanged(
+                scenario,
+                initialWidth,
+                initialHeight
+            )
+
+            assertCanvasCssDimensionsDecreased(
+                scenario,
+                initialWidth,
+                initialHeight,
+                "$zoomInput zoom out"
+            )
+            assertTextLayerStillRendered(scenario)
+        }
+    }
+
+    @Test
+    fun zoomOut_clampsToMinimumZoomRatio() {
+        PdfViewerLauncher.launchWithTestAsset("test-simple.pdf").use { scenario ->
+            PdfViewerTestUtils.waitForDocumentFullyLoaded(scenario)
+            PdfViewerTestUtils.waitForCanvasRendered(scenario)
+
+            zoomInput.zoomOutUntilClamp(robot, scenario)
+
+            PdfViewerTestUtils.pollUntil(
+                timeout = 15_000,
+                description = {
+                    "$zoomInput zoom out did not clamp to MIN_ZOOM_RATIO " +
+                            "(was ${robot.getZoomRatio(scenario)})"
+                }
+            ) {
+                abs(robot.getZoomRatio(scenario) - MIN_ZOOM_RATIO) < 0.001f
+            }
+        }
+    }
+
+    private fun waitForZoomRatioAbove(
+        scenario: ActivityScenario<PdfViewer>,
+        initialZoomRatio: Float,
+        action: String
+    ) {
+        PdfViewerTestUtils.pollUntil(
+            timeout = 15_000,
+            description = {
+                "Zoom ratio should increase after $action " +
+                        "(initial=$initialZoomRatio, current=${robot.getZoomRatio(scenario)})"
+            }
+        ) {
+            robot.getZoomRatio(scenario) > initialZoomRatio
+        }
+    }
+
+    private fun waitForZoomRatioBelow(
+        scenario: ActivityScenario<PdfViewer>,
+        initialZoomRatio: Float,
+        action: String
+    ) {
+        PdfViewerTestUtils.pollUntil(
+            timeout = 15_000,
+            description = {
+                "Zoom ratio should decrease after $action " +
+                        "(initial=$initialZoomRatio, current=${robot.getZoomRatio(scenario)})"
+            }
+        ) {
+            robot.getZoomRatio(scenario) < initialZoomRatio
+        }
+    }
+
+    private fun assertCanvasCssDimensionsIncreased(
+        scenario: ActivityScenario<PdfViewer>,
+        initialWidth: Int,
+        initialHeight: Int,
+        action: String
+    ) {
+        val zoomedWidth = robot.getCanvasCssWidth(scenario)
+        val zoomedHeight = robot.getCanvasCssHeight(scenario)
+        assertTrue(
+            "Canvas CSS width should increase after $action ($initialWidth -> $zoomedWidth)",
+            zoomedWidth > initialWidth
+        )
+        assertTrue(
+            "Canvas CSS height should increase after $action ($initialHeight -> $zoomedHeight)",
+            zoomedHeight > initialHeight
+        )
+    }
+
+    private fun assertCanvasCssDimensionsDecreased(
+        scenario: ActivityScenario<PdfViewer>,
+        initialWidth: Int,
+        initialHeight: Int,
+        action: String
+    ) {
+        val zoomedWidth = robot.getCanvasCssWidth(scenario)
+        val zoomedHeight = robot.getCanvasCssHeight(scenario)
+        assertTrue(
+            "Canvas CSS width should decrease after $action ($initialWidth -> $zoomedWidth)",
+            zoomedWidth < initialWidth
+        )
+        assertTrue(
+            "Canvas CSS height should decrease after $action ($initialHeight -> $zoomedHeight)",
+            zoomedHeight < initialHeight
+        )
+    }
+
+    private fun assertTextLayerStillRendered(scenario: ActivityScenario<PdfViewer>) {
+        PdfViewerTestUtils.waitForCanvasRendered(scenario)
+        PdfViewerTestUtils.assertTextLayerContent(scenario, "Test Text")
+        robot.assertTextLayerAligned(scenario)
+    }
+}

--- a/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/util/PdfViewerRobot.kt
+++ b/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/util/PdfViewerRobot.kt
@@ -241,6 +241,61 @@ class PdfViewerRobot(private val composeRule: ComposeTestRule) {
         composeRule.waitForIdle()
     }
 
+    fun performMouseSwipe(
+        scenario: ActivityScenario<PdfViewer>,
+        left: Boolean
+    ) = performPointerSwipe(
+        scenario,
+        left,
+        InputDevice.SOURCE_MOUSE
+    )
+
+    fun performTouchSwipe(
+        scenario: ActivityScenario<PdfViewer>,
+        left: Boolean
+    ) = performPointerSwipe(
+        scenario,
+        left,
+        InputDevice.SOURCE_TOUCHSCREEN
+    )
+
+    private fun performPointerSwipe(
+        scenario: ActivityScenario<PdfViewer>,
+        left: Boolean,
+        source: Int
+    ) {
+        scenario.onActivity { activity ->
+            val webView = activity.webView ?: throw AssertionError("WebView is null")
+            val startPercent = if (left) 0.8f else 0.2f
+            val endPercent = if (left) 0.2f else 0.8f
+            val startX = webView.width * startPercent
+            val endX = webView.width * endPercent
+            val y = webView.height / 2f
+            val downTime = SystemClock.uptimeMillis()
+
+            fun dispatch(action: Int, elapsedTime: Long, x: Float) {
+                val event = obtainPointerEvent(
+                    downTime,
+                    downTime + elapsedTime,
+                    action,
+                    x,
+                    y,
+                    source
+                )
+                try {
+                    webView.dispatchTouchEvent(event)
+                } finally {
+                    event.recycle()
+                }
+            }
+
+            dispatch(MotionEvent.ACTION_DOWN, 0, startX)
+            dispatch(MotionEvent.ACTION_MOVE, 10, (startX + endX) / 2f)
+            dispatch(MotionEvent.ACTION_UP, 20, endX)
+        }
+        composeRule.waitForIdle()
+    }
+
     fun clickReload() {
         composeRule.onNodeWithTag(TestTags.RELOAD_BUTTON).performClick()
     }
@@ -483,33 +538,15 @@ class PdfViewerRobot(private val composeRule: ComposeTestRule) {
         scenario.onActivity { activity ->
             val webView = activity.webView ?: throw AssertionError("WebView is null")
             val eventTime = SystemClock.uptimeMillis()
-            val coords = MotionEvent.PointerCoords().apply {
-                x = webView.width / 2f
-                y = webView.height / 2f
-                setAxisValue(
-                    MotionEvent.AXIS_VSCROLL,
-                    if (zoomIn) 1f else -1f
-                )
-            }
-            val properties = MotionEvent.PointerProperties().apply {
-                id = 0
-                toolType = MotionEvent.TOOL_TYPE_MOUSE
-            }
-            val event = MotionEvent.obtain(
+            val event = obtainPointerEvent(
                 eventTime,
                 eventTime,
                 MotionEvent.ACTION_SCROLL,
-                1,
-                arrayOf(properties),
-                arrayOf(coords),
-                KeyEvent.META_CTRL_ON,
-                0,
-                0f,
-                0f,
-                0,
-                0,
+                webView.width / 2f,
+                webView.height / 2f,
                 InputDevice.SOURCE_MOUSE,
-                0
+                verticalScroll = if (zoomIn) 1f else -1f,
+                ctrlPressed = true
             )
 
             try {
@@ -518,6 +555,64 @@ class PdfViewerRobot(private val composeRule: ComposeTestRule) {
                 event.recycle()
             }
         }
+    }
+
+    private fun obtainPointerEvent(
+        downTime: Long,
+        eventTime: Long,
+        action: Int,
+        x: Float,
+        y: Float,
+        source: Int,
+        verticalScroll: Float = 0f,
+        ctrlPressed: Boolean = false
+    ): MotionEvent {
+        val isScroll = action == MotionEvent.ACTION_SCROLL
+        val isMouse = source == InputDevice.SOURCE_MOUSE
+        val coords = MotionEvent.PointerCoords().apply {
+            this.x = x
+            this.y = y
+            if (isScroll) {
+                setAxisValue(MotionEvent.AXIS_VSCROLL, verticalScroll)
+            } else {
+                pressure = 1f
+                size = 1f
+            }
+        }
+        val properties = MotionEvent.PointerProperties().apply {
+            id = 0
+            toolType = if (isMouse) {
+                MotionEvent.TOOL_TYPE_MOUSE
+            } else {
+                MotionEvent.TOOL_TYPE_FINGER
+            }
+        }
+        val buttonState = if (
+            isMouse &&
+            !isScroll &&
+            action != MotionEvent.ACTION_UP
+        ) {
+            MotionEvent.BUTTON_PRIMARY
+        } else {
+            0
+        }
+        val precision = if (isScroll) 0f else 1f
+        return MotionEvent.obtain(
+            downTime,
+            eventTime,
+            action,
+            1,
+            arrayOf(properties),
+            arrayOf(coords),
+            if (ctrlPressed) KeyEvent.META_CTRL_ON else 0,
+            buttonState,
+            precision,
+            precision,
+            0,
+            0,
+            source,
+            0
+        )
     }
 
     private fun findWebViewObject(): UiObject2 {

--- a/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/util/PdfViewerRobot.kt
+++ b/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/util/PdfViewerRobot.kt
@@ -291,7 +291,8 @@ class PdfViewerRobot(private val composeRule: ComposeTestRule) {
 
             dispatch(MotionEvent.ACTION_DOWN, 0, startX)
             dispatch(MotionEvent.ACTION_MOVE, 10, (startX + endX) / 2f)
-            dispatch(MotionEvent.ACTION_UP, 20, endX)
+            dispatch(MotionEvent.ACTION_MOVE, 20, endX)
+            dispatch(MotionEvent.ACTION_UP, 1020, endX)
         }
         composeRule.waitForIdle()
     }

--- a/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/util/PdfViewerRobot.kt
+++ b/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/util/PdfViewerRobot.kt
@@ -89,6 +89,11 @@ class PdfViewerRobot(private val composeRule: ComposeTestRule) {
         SaveError(R.string.error_while_saving)
     }
 
+    enum class KeyboardArrow(internal val keyCode: Int) {
+        Left(KeyEvent.KEYCODE_DPAD_LEFT),
+        Right(KeyEvent.KEYCODE_DPAD_RIGHT)
+    }
+
     // WebView
 
     fun assertWebViewVisible() {
@@ -222,6 +227,20 @@ class PdfViewerRobot(private val composeRule: ComposeTestRule) {
 
     fun clickNext() = click(AppMenuItem.Next)
     fun clickPrevious() = click(AppMenuItem.Previous)
+    fun pressKeyboardArrow(
+        scenario: ActivityScenario<PdfViewer>,
+        arrow: KeyboardArrow
+    ) {
+        scenario.onActivity { activity ->
+            val webView = activity.webView ?: throw AssertionError("WebView is null")
+            webView.requestFocus()
+        }
+        composeRule.waitForIdle()
+
+        InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(arrow.keyCode)
+        composeRule.waitForIdle()
+    }
+
     fun clickReload() {
         composeRule.onNodeWithTag(TestTags.RELOAD_BUTTON).performClick()
     }

--- a/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/util/PdfViewerRobot.kt
+++ b/app/src/androidTest/kotlin/app/grapheneos/pdfviewer/util/PdfViewerRobot.kt
@@ -1,6 +1,10 @@
 package app.grapheneos.pdfviewer.util
 
 import android.graphics.Rect
+import android.os.SystemClock
+import android.view.InputDevice
+import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.View
 import android.webkit.WebView
 import androidx.annotation.StringRes
@@ -451,6 +455,50 @@ class PdfViewerRobot(private val composeRule: ComposeTestRule) {
         val webView = findWebViewObject()
         applyContentGestureMargins(webView, scenario)
         webView.pinchClose(percent, speed)
+    }
+
+    fun performCtrlMouseWheelZoom(
+        scenario: ActivityScenario<PdfViewer>,
+        zoomIn: Boolean
+    ) {
+        scenario.onActivity { activity ->
+            val webView = activity.webView ?: throw AssertionError("WebView is null")
+            val eventTime = SystemClock.uptimeMillis()
+            val coords = MotionEvent.PointerCoords().apply {
+                x = webView.width / 2f
+                y = webView.height / 2f
+                setAxisValue(
+                    MotionEvent.AXIS_VSCROLL,
+                    if (zoomIn) 1f else -1f
+                )
+            }
+            val properties = MotionEvent.PointerProperties().apply {
+                id = 0
+                toolType = MotionEvent.TOOL_TYPE_MOUSE
+            }
+            val event = MotionEvent.obtain(
+                eventTime,
+                eventTime,
+                MotionEvent.ACTION_SCROLL,
+                1,
+                arrayOf(properties),
+                arrayOf(coords),
+                KeyEvent.META_CTRL_ON,
+                0,
+                0f,
+                0f,
+                0,
+                0,
+                InputDevice.SOURCE_MOUSE,
+                0
+            )
+
+            try {
+                webView.dispatchGenericMotionEvent(event)
+            } finally {
+                event.recycle()
+            }
+        }
     }
 
     private fun findWebViewObject(): UiObject2 {

--- a/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.kt
@@ -22,7 +22,9 @@ object GestureHelper {
 
     interface GestureListener {
         fun onTapUp(): Boolean
-        fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean
+        fun onSwipeStart()
+        fun onSwipeProgress(e1: MotionEvent?, e2: MotionEvent)
+        fun onSwipeEnd()
         fun onZoom(scaleFactor: Float, focusX: Float, focusY: Float)
         fun onCtrlMouseWheelZoom(zoomIn: Boolean, focusX: Float, focusY: Float)
         fun onZoomEnd()
@@ -53,28 +55,36 @@ object GestureHelper {
                     return listener.onTapUp()
                 }
 
-                override fun onFling(
+                override fun onScroll(
                     e1: MotionEvent?,
                     e2: MotionEvent,
-                    velocityX: Float,
-                    velocityY: Float
+                    distanceX: Float,
+                    distanceY: Float
                 ): Boolean {
-                    if (wasScaling) return false
+                    if (wasScaling || e2.pointerCount != 1) return false
                     if (isMouseEvent(e1) || isMouseEvent(e2)) return false
-                    return listener.onFling(e1, e2, velocityX, velocityY)
+                    listener.onSwipeProgress(e1, e2)
+                    return false
                 }
             })
 
         gestureView.setOnTouchListener { _, event ->
             if (event.actionMasked == MotionEvent.ACTION_DOWN) {
                 wasScaling = false
+                listener.onSwipeStart()
             }
 
             detector.onTouchEvent(event)
             scaleDetector.onTouchEvent(event)
 
-            if (scaleDetector.isInProgress) {
+            if (event.pointerCount > 1 || scaleDetector.isInProgress) {
                 wasScaling = true
+            }
+            if (event.actionMasked == MotionEvent.ACTION_UP &&
+                !wasScaling &&
+                !isMouseEvent(event)
+            ) {
+                listener.onSwipeEnd()
             }
 
             false

--- a/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.kt
@@ -60,6 +60,7 @@ object GestureHelper {
                     velocityY: Float
                 ): Boolean {
                     if (wasScaling) return false
+                    if (isMouseEvent(e1) || isMouseEvent(e2)) return false
                     return listener.onFling(e1, e2, velocityX, velocityY)
                 }
             })
@@ -106,6 +107,19 @@ object GestureHelper {
                 (event.source and InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE &&
                 event.getToolType(0) == MotionEvent.TOOL_TYPE_MOUSE &&
                 event.getAxisValue(MotionEvent.AXIS_VSCROLL) != 0f
+    }
+
+    private fun isMouseEvent(event: MotionEvent?): Boolean {
+        if (event == null) return false
+        if ((event.source and InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE) {
+            return true
+        }
+        for (pointerIndex in 0 until event.pointerCount) {
+            if (event.getToolType(pointerIndex) == MotionEvent.TOOL_TYPE_MOUSE) {
+                return true
+            }
+        }
+        return false
     }
 
     fun getKeyboardPageNavigationDirection(event: KeyEvent): PageNavigationDirection? {

--- a/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.kt
@@ -2,10 +2,13 @@ package app.grapheneos.pdfviewer
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.view.InputDevice
 import android.view.GestureDetector
+import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import android.view.View
+import kotlin.math.roundToInt
 
 /*
  * The GestureHelper present a simple gesture api for the PdfViewer
@@ -16,12 +19,14 @@ object GestureHelper {
         fun onTapUp(): Boolean
         fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean
         fun onZoom(scaleFactor: Float, focusX: Float, focusY: Float)
+        fun onCtrlMouseWheelZoom(zoomIn: Boolean, focusX: Float, focusY: Float)
         fun onZoomEnd()
     }
 
     @SuppressLint("ClickableViewAccessibility")
     fun attach(context: Context, gestureView: View, listener: GestureListener) {
         var wasScaling = false
+        var wheelTickRemainder = 0f
 
         val scaleDetector = ScaleGestureDetector(
             context,
@@ -68,5 +73,33 @@ object GestureHelper {
 
             false
         }
+
+        gestureView.setOnGenericMotionListener { _, event ->
+            if (!isCtrlPhysicalMouseWheelEvent(event)) {
+                return@setOnGenericMotionListener false
+            }
+
+            wheelTickRemainder += event.getAxisValue(MotionEvent.AXIS_VSCROLL)
+            val wholeTickDelta = wheelTickRemainder.roundToInt()
+            wheelTickRemainder -= wholeTickDelta
+            if (wholeTickDelta != 0) {
+                listener.onCtrlMouseWheelZoom(
+                    zoomIn = wholeTickDelta > 0,
+                    focusX = event.x,
+                    focusY = event.y
+                )
+            }
+
+            true
+        }
+    }
+
+    private fun isCtrlPhysicalMouseWheelEvent(event: MotionEvent): Boolean {
+        return event.actionMasked == MotionEvent.ACTION_SCROLL &&
+                event.pointerCount > 0 &&
+                (event.metaState and KeyEvent.META_CTRL_ON) != 0 &&
+                (event.source and InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE &&
+                event.getToolType(0) == MotionEvent.TOOL_TYPE_MOUSE &&
+                event.getAxisValue(MotionEvent.AXIS_VSCROLL) != 0f
     }
 }

--- a/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/GestureHelper.kt
@@ -15,6 +15,11 @@ import kotlin.math.roundToInt
  */
 
 object GestureHelper {
+    enum class PageNavigationDirection(val pageOffset: Int) {
+        Previous(-1),
+        Next(1)
+    }
+
     interface GestureListener {
         fun onTapUp(): Boolean
         fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean
@@ -101,5 +106,20 @@ object GestureHelper {
                 (event.source and InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE &&
                 event.getToolType(0) == MotionEvent.TOOL_TYPE_MOUSE &&
                 event.getAxisValue(MotionEvent.AXIS_VSCROLL) != 0f
+    }
+
+    fun getKeyboardPageNavigationDirection(event: KeyEvent): PageNavigationDirection? {
+        if (!isPlainKeyDown(event)) return null
+
+        return when (event.keyCode) {
+            KeyEvent.KEYCODE_DPAD_LEFT -> PageNavigationDirection.Previous
+            KeyEvent.KEYCODE_DPAD_RIGHT -> PageNavigationDirection.Next
+            else -> null
+        }
+    }
+
+    private fun isPlainKeyDown(event: KeyEvent): Boolean {
+        return event.action == KeyEvent.ACTION_DOWN &&
+                event.hasNoModifiers()
     }
 }

--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewerScreen.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewerScreen.kt
@@ -9,7 +9,6 @@ import android.icu.text.NumberFormat
 import android.util.Log
 import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
-import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.RenderProcessGoneDetail
@@ -141,9 +140,22 @@ private val ZOOM_PRESETS = intArrayOf(25, 50, 75, 100, 125, 150, 200, 300, 500, 
 private const val MOUSE_WHEEL_ZOOM_IN_FACTOR = 1.25f
 private const val MOUSE_WHEEL_ZOOM_OUT_FACTOR = 0.8f
 private const val MOUSE_WHEEL_ZOOM_END_DELAY_MS = 120L
+// Chromium uses a 30-degree direction gate and a 32dp pull distance with 3x activation.
+private const val PAGE_SWIPE_DIRECTION_WEIGHT = 1.73f
+private val PAGE_SWIPE_THRESHOLD = 96.dp
 private const val RENDER_DEFAULT_SCRIPT = "renderDefault()"
 private const val RENDER_FINAL_ZOOM_SCRIPT = "renderFinalZoom()"
 private const val RENDER_TRANSIENT_ZOOM_SCRIPT = "renderTransientZoom()"
+
+// Expose protected scroll metrics needed to measure movement past the content bounds.
+private class PdfWebView(context: Context) : WebView(context) {
+    val horizontalScrollOffset: Int
+        get() = computeHorizontalScrollOffset()
+
+    val maximumHorizontalScrollOffset: Int
+        get() = (computeHorizontalScrollRange() - computeHorizontalScrollExtent())
+            .coerceAtLeast(0)
+}
 
 private fun nextZoomPreset(ratio: Float): Float? {
     val currentPercent = (ratio * 100).roundToInt()
@@ -265,7 +277,7 @@ fun PdfViewerScreen(
     var webViewRelease by remember { mutableIntStateOf(getWebViewRelease()) }
     val webViewOk = webViewRelease >= MIN_WEBVIEW_RELEASE
     var toolbarHeightPx by remember { mutableFloatStateOf(0f) }
-    var webView by remember { mutableStateOf<WebView?>(null) }
+    var webView by remember { mutableStateOf<PdfWebView?>(null) }
 
     LifecycleResumeEffect(Unit) {
         webViewRelease = getWebViewRelease()
@@ -341,8 +353,7 @@ fun PdfViewerScreen(
         }
     }
 
-    val viewConfiguration = remember { ViewConfiguration.get(context) }
-    val swipeThreshold = remember { viewConfiguration.scaledTouchSlop * 6 }
+    val swipeThreshold = with(density) { PAGE_SWIPE_THRESHOLD.toPx() }
 
     DisposableEffect(webView) {
         val wv = webView ?: return@DisposableEffect onDispose {}
@@ -363,23 +374,34 @@ fun PdfViewerScreen(
             return true
         }
 
+        var pageSwipeStartScrollOffset = 0
+        var pageSwipeMaximumScrollOffset = 0
+
         fun pageSwipeDirection(
             e1: MotionEvent?,
             e2: MotionEvent
         ): GestureHelper.PageNavigationDirection? {
             if (e1 == null) return null
 
-            val deltaX = e2.x - e1.x
-            val deltaY = e2.y - e1.y
-            if (abs(deltaX) <= abs(deltaY) || abs(deltaX) <= swipeThreshold) return null
+            val distanceX = e1.x - e2.x
+            val distanceY = e1.y - e2.y
+            if (abs(distanceX) <= abs(distanceY) * PAGE_SWIPE_DIRECTION_WEIGHT) return null
+
+            val distancePastBound = when {
+                distanceX > 0 ->
+                    (distanceX - (pageSwipeMaximumScrollOffset - pageSwipeStartScrollOffset))
+                        .coerceAtLeast(0f)
+                distanceX < 0 ->
+                    (distanceX + pageSwipeStartScrollOffset).coerceAtMost(0f)
+                else -> 0f
+            }
+            if (abs(distancePastBound) <= swipeThreshold) return null
 
             return when {
-                deltaX < 0 &&
-                        !wv.canScrollHorizontally(1) &&
+                distancePastBound > 0 &&
                         viewModel.page.value < viewModel.numPages.value ->
                     GestureHelper.PageNavigationDirection.Next
-                deltaX > 0 &&
-                        !wv.canScrollHorizontally(-1) &&
+                distancePastBound < 0 &&
                         viewModel.page.value > 1 ->
                     GestureHelper.PageNavigationDirection.Previous
                 else -> null
@@ -399,6 +421,11 @@ fun PdfViewerScreen(
             }
 
             override fun onSwipeStart() {
+                pageSwipeMaximumScrollOffset = wv.maximumHorizontalScrollOffset
+                pageSwipeStartScrollOffset = wv.horizontalScrollOffset.coerceIn(
+                    0,
+                    pageSwipeMaximumScrollOffset
+                )
                 eligiblePageSwipeDirection = null
             }
 
@@ -541,7 +568,7 @@ fun PdfViewerScreen(
             else -> {
                 AndroidView(
                     factory = { ctx ->
-                        WebView(ctx).apply {
+                        PdfWebView(ctx).apply {
                             layoutParams = ViewGroup.LayoutParams(
                                 ViewGroup.LayoutParams.MATCH_PARENT,
                                 ViewGroup.LayoutParams.MATCH_PARENT

--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewerScreen.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewerScreen.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.icu.text.DecimalFormatSymbols
 import android.icu.text.NumberFormat
 import android.util.Log
+import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import android.view.ViewConfiguration
 import android.view.ViewGroup
@@ -342,7 +343,6 @@ fun PdfViewerScreen(
 
     val viewConfiguration = remember { ViewConfiguration.get(context) }
     val swipeThreshold = remember { viewConfiguration.scaledTouchSlop * 6 }
-    val swipeVelocityThreshold = remember { viewConfiguration.scaledMinimumFlingVelocity }
 
     DisposableEffect(webView) {
         val wv = webView ?: return@DisposableEffect onDispose {}
@@ -363,6 +363,30 @@ fun PdfViewerScreen(
             return true
         }
 
+        fun pageSwipeDirection(
+            e1: MotionEvent?,
+            e2: MotionEvent
+        ): GestureHelper.PageNavigationDirection? {
+            if (e1 == null) return null
+
+            val deltaX = e2.x - e1.x
+            val deltaY = e2.y - e1.y
+            if (abs(deltaX) <= abs(deltaY) || abs(deltaX) <= swipeThreshold) return null
+
+            return when {
+                deltaX < 0 &&
+                        !wv.canScrollHorizontally(1) &&
+                        viewModel.page.value < viewModel.numPages.value ->
+                    GestureHelper.PageNavigationDirection.Next
+                deltaX > 0 &&
+                        !wv.canScrollHorizontally(-1) &&
+                        viewModel.page.value > 1 ->
+                    GestureHelper.PageNavigationDirection.Previous
+                else -> null
+            }
+        }
+
+        var eligiblePageSwipeDirection: GestureHelper.PageNavigationDirection? = null
         GestureHelper.attach(context, wv, object : GestureHelper.GestureListener {
             override fun onTapUp(): Boolean {
                 if (viewModel.uri.value == null) return false
@@ -374,28 +398,27 @@ fun PdfViewerScreen(
                 return true
             }
 
-            override fun onFling(
-                e1: MotionEvent?, e2: MotionEvent,
-                velocityX: Float, velocityY: Float
-            ): Boolean {
-                if (e1 == null) return false
+            override fun onSwipeStart() {
+                eligiblePageSwipeDirection = null
+            }
 
-                val deltaX = e2.x - e1.x
-                val deltaY = e2.y - e1.y
-
-                if (abs(deltaX) > abs(deltaY) &&
-                    abs(deltaX) > swipeThreshold &&
-                    abs(velocityX) > swipeVelocityThreshold
-                ) {
-                    if (deltaX < 0 && !wv.canScrollHorizontally(1)) {
-                        jumpToPage(viewModel, wv, viewModel.page.value + 1)
-                        return true
-                    } else if (deltaX > 0 && !wv.canScrollHorizontally(-1)) {
-                        jumpToPage(viewModel, wv, viewModel.page.value - 1)
-                        return true
-                    }
+            override fun onSwipeProgress(e1: MotionEvent?, e2: MotionEvent) {
+                val direction = pageSwipeDirection(e1, e2)
+                if (direction != null && direction != eligiblePageSwipeDirection) {
+                    wv.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
                 }
-                return false
+                eligiblePageSwipeDirection = direction
+            }
+
+            override fun onSwipeEnd() {
+                eligiblePageSwipeDirection?.let { direction ->
+                    jumpToPage(
+                        viewModel,
+                        wv,
+                        viewModel.page.value + direction.pageOffset
+                    )
+                }
+                eligiblePageSwipeDirection = null
             }
 
             override fun onZoom(scaleFactor: Float, focusX: Float, focusY: Float) {

--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewerScreen.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewerScreen.kt
@@ -136,6 +136,9 @@ import kotlin.math.roundToInt
 private const val TAG = "PdfViewerScreen"
 private const val MIN_WEBVIEW_RELEASE = 133
 private val ZOOM_PRESETS = intArrayOf(25, 50, 75, 100, 125, 150, 200, 300, 500, 750, 1000)
+private const val RENDER_DEFAULT_SCRIPT = "renderDefault()"
+private const val RENDER_FINAL_ZOOM_SCRIPT = "renderFinalZoom()"
+private const val RENDER_TRANSIENT_ZOOM_SCRIPT = "renderTransientZoom()"
 
 private fun nextZoomPreset(ratio: Float): Float? {
     val currentPercent = (ratio * 100).roundToInt()
@@ -381,11 +384,11 @@ fun PdfViewerScreen(
                 )
                 viewModel.zoomFocusX = focusX
                 viewModel.zoomFocusY = focusY
-                wv.evaluateJavascript("onRenderPage(2)", null)
+                wv.evaluateJavascript(RENDER_TRANSIENT_ZOOM_SCRIPT, null)
             }
 
             override fun onZoomEnd() {
-                wv.evaluateJavascript("onRenderPage(1)", null)
+                wv.evaluateJavascript(RENDER_FINAL_ZOOM_SCRIPT, null)
             }
         })
         onDispose {
@@ -764,7 +767,7 @@ internal fun jumpToPage(viewModel: PdfViewModel, webView: WebView?, selectedPage
     val num = viewModel.numPages.value
     if (selectedPage in 1..num && viewModel.page.value != selectedPage) {
         viewModel.setPage(selectedPage)
-        webView.evaluateJavascript("onRenderPage(0)", null)
+        webView.evaluateJavascript(RENDER_DEFAULT_SCRIPT, null)
         viewModel.showPageIndicator()
     }
 }
@@ -774,13 +777,13 @@ private fun rotateDocument(viewModel: PdfViewModel, webView: WebView?, offset: I
     var degrees = (viewModel.documentOrientationDegrees.value + offset) % 360
     if (degrees < 0) degrees += 360
     viewModel.setDocumentOrientationDegrees(degrees)
-    webView.evaluateJavascript("onRenderPage(0)", null)
+    webView.evaluateJavascript(RENDER_DEFAULT_SCRIPT, null)
 }
 
 private fun zoomDocument(viewModel: PdfViewModel, webView: WebView?, ratio: Float) {
     webView ?: return
     viewModel.setZoomRatio(ratio.coerceIn(MIN_ZOOM_RATIO, MAX_ZOOM_RATIO))
-    webView.evaluateJavascript("onRenderPage(1)", null)
+    webView.evaluateJavascript(RENDER_FINAL_ZOOM_SCRIPT, null)
 }
 
 private fun shareDocument(context: Context, viewModel: PdfViewModel) {

--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewerScreen.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewerScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -468,8 +469,31 @@ fun PdfViewerScreen(
     val hasPages = numPages > 0
     val enabled = documentLoaded && !webViewCrashed
     val displayName = documentName.ifEmpty { stringResource(R.string.app_name) }
+    val keyboardPageNavigationEnabled = enabled &&
+            !showMenu &&
+            !showOutline &&
+            !showJumpToPage &&
+            !showDocProperties &&
+            !showCustomZoom &&
+            !showPasswordDialog
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .onPreviewKeyEvent { event ->
+                if (!keyboardPageNavigationEnabled) {
+                    return@onPreviewKeyEvent false
+                }
+                val direction =
+                    GestureHelper.getKeyboardPageNavigationDirection(event.nativeKeyEvent)
+                        ?: return@onPreviewKeyEvent false
+                jumpToPage(
+                    viewModel,
+                    webView,
+                    viewModel.page.value + direction.pageOffset
+                )
+            }
+    ) {
         when {
             webViewCrashed -> WebViewAlertScreen(
                 title = stringResource(R.string.webview_crash_title),
@@ -792,14 +816,16 @@ private fun loadPdfWithPassword(viewModel: PdfViewModel, webView: WebView?, pass
     webView.evaluateJavascript("loadDocument()", null)
 }
 
-internal fun jumpToPage(viewModel: PdfViewModel, webView: WebView?, selectedPage: Int) {
-    webView ?: return
+internal fun jumpToPage(viewModel: PdfViewModel, webView: WebView?, selectedPage: Int): Boolean {
+    webView ?: return false
     val num = viewModel.numPages.value
     if (selectedPage in 1..num && viewModel.page.value != selectedPage) {
         viewModel.setPage(selectedPage)
         webView.evaluateJavascript(RENDER_DEFAULT_SCRIPT, null)
         viewModel.showPageIndicator()
+        return true
     }
+    return false
 }
 
 private fun rotateDocument(viewModel: PdfViewModel, webView: WebView?, offset: Int) {

--- a/app/src/main/java/app/grapheneos/pdfviewer/PdfViewerScreen.kt
+++ b/app/src/main/java/app/grapheneos/pdfviewer/PdfViewerScreen.kt
@@ -136,6 +136,9 @@ import kotlin.math.roundToInt
 private const val TAG = "PdfViewerScreen"
 private const val MIN_WEBVIEW_RELEASE = 133
 private val ZOOM_PRESETS = intArrayOf(25, 50, 75, 100, 125, 150, 200, 300, 500, 750, 1000)
+private const val MOUSE_WHEEL_ZOOM_IN_FACTOR = 1.25f
+private const val MOUSE_WHEEL_ZOOM_OUT_FACTOR = 0.8f
+private const val MOUSE_WHEEL_ZOOM_END_DELAY_MS = 120L
 private const val RENDER_DEFAULT_SCRIPT = "renderDefault()"
 private const val RENDER_FINAL_ZOOM_SCRIPT = "renderFinalZoom()"
 private const val RENDER_TRANSIENT_ZOOM_SCRIPT = "renderTransientZoom()"
@@ -342,6 +345,23 @@ fun PdfViewerScreen(
 
     DisposableEffect(webView) {
         val wv = webView ?: return@DisposableEffect onDispose {}
+        val renderMouseWheelZoomEnd = Runnable {
+            wv.evaluateJavascript(RENDER_FINAL_ZOOM_SCRIPT, null)
+        }
+
+        fun renderTransientZoom(scaleFactor: Float, focusX: Float, focusY: Float): Boolean {
+            val currentZoomRatio = viewModel.zoomRatio.value
+            if (currentZoomRatio == 0f) return false
+
+            viewModel.setZoomRatio(
+                (currentZoomRatio * scaleFactor).coerceIn(MIN_ZOOM_RATIO, MAX_ZOOM_RATIO)
+            )
+            viewModel.zoomFocusX = focusX
+            viewModel.zoomFocusY = focusY
+            wv.evaluateJavascript(RENDER_TRANSIENT_ZOOM_SCRIPT, null)
+            return true
+        }
+
         GestureHelper.attach(context, wv, object : GestureHelper.GestureListener {
             override fun onTapUp(): Boolean {
                 if (viewModel.uri.value == null) return false
@@ -378,13 +398,21 @@ fun PdfViewerScreen(
             }
 
             override fun onZoom(scaleFactor: Float, focusX: Float, focusY: Float) {
-                viewModel.setZoomRatio(
-                    (viewModel.zoomRatio.value * scaleFactor)
-                        .coerceIn(MIN_ZOOM_RATIO, MAX_ZOOM_RATIO)
-                )
-                viewModel.zoomFocusX = focusX
-                viewModel.zoomFocusY = focusY
-                wv.evaluateJavascript(RENDER_TRANSIENT_ZOOM_SCRIPT, null)
+                wv.removeCallbacks(renderMouseWheelZoomEnd)
+                renderTransientZoom(scaleFactor, focusX, focusY)
+            }
+
+            override fun onCtrlMouseWheelZoom(zoomIn: Boolean, focusX: Float, focusY: Float) {
+                val scaleFactor = if (zoomIn) {
+                    MOUSE_WHEEL_ZOOM_IN_FACTOR
+                } else {
+                    MOUSE_WHEEL_ZOOM_OUT_FACTOR
+                }
+
+                if (!renderTransientZoom(scaleFactor, focusX, focusY)) return
+
+                wv.removeCallbacks(renderMouseWheelZoomEnd)
+                wv.postDelayed(renderMouseWheelZoomEnd, MOUSE_WHEEL_ZOOM_END_DELAY_MS)
             }
 
             override fun onZoomEnd() {
@@ -392,7 +420,9 @@ fun PdfViewerScreen(
             }
         })
         onDispose {
+            wv.removeCallbacks(renderMouseWheelZoomEnd)
             wv.setOnTouchListener(null)
+            wv.setOnGenericMotionListener(null)
         }
     }
 

--- a/viewer/js/index.js
+++ b/viewer/js/index.js
@@ -18,6 +18,8 @@ let outlineAbort = new AbortController();
 let pageRendering = false;
 let renderPending = false;
 let renderPendingMode = RENDER_MODE_DEFAULT;
+let activeRenderMode = RENDER_MODE_DEFAULT;
+let finalZoomPending = false;
 const canvas = document.getElementById("content");
 const container = document.getElementById("container");
 let orientationDegrees = 0;
@@ -37,7 +39,6 @@ let userZoomed = false;
 
 function maybeRenderNextPage() {
     if (renderPending) {
-        pageRendering = false;
         renderPending = false;
         renderPage(channel.getPage(), renderPendingMode, false);
         return true;
@@ -47,9 +48,7 @@ function maybeRenderNextPage() {
 
 function handleRenderingError(error) {
     console.log("rendering error: " + error);
-
-    pageRendering = false;
-    maybeRenderNextPage();
+    finishRenderingAndContinueQueue();
 }
 
 function doPrerender(pageNumber, prerenderTrigger) {
@@ -115,9 +114,34 @@ function isTransientZoomRender(renderMode) {
     return renderMode === RENDER_MODE_TRANSIENT_ZOOM;
 }
 
+function isTransientZoomQueuedOrRendering() {
+    return isTransientZoomRender(activeRenderMode) ||
+            (renderPending && isTransientZoomRender(renderPendingMode));
+}
+
+function renderFinalZoomIfPending() {
+    if (!finalZoomPending) {
+        return;
+    }
+
+    finalZoomPending = false;
+    renderPage(channel.getPage(), RENDER_MODE_FINAL_ZOOM, false);
+}
+
+function finishRenderingAndContinueQueue() {
+    pageRendering = false;
+    if (!maybeRenderNextPage()) {
+        renderFinalZoomIfPending();
+    }
+}
+
 function renderPage(pageNumber, renderMode, prerender, prerenderTrigger = 0) {
     pageRendering = true;
     useRender = !prerender;
+    activeRenderMode = renderMode;
+    if (!isTransientZoomRender(renderMode)) {
+        finalZoomPending = false;
+    }
 
     newPageNumber = pageNumber;
     newZoomRatio = channel.getZoomRatio();
@@ -193,7 +217,7 @@ function renderPage(pageNumber, renderMode, prerender, prerenderTrigger = 0) {
 
             if (isTransientZoomRender(renderMode)) {
                 textLayerDiv.hidden = true;
-                pageRendering = false;
+                finishRenderingAndContinueQueue();
                 return;
             }
         }
@@ -296,6 +320,11 @@ function requestRender(renderMode) {
     }
 
     if (pageRendering) {
+        if (isFinalZoomRender(renderMode) && isTransientZoomQueuedOrRendering()) {
+            finalZoomPending = true;
+            return;
+        }
+
         if (newPageNumber === channel.getPage() && newZoomRatio === channel.getZoomRatio() &&
                 orientationDegrees === channel.getDocumentOrientationDegrees()) {
             useRender = true;

--- a/viewer/js/index.js
+++ b/viewer/js/index.js
@@ -311,7 +311,7 @@ function renderPage(pageNumber, renderMode, prerender, prerenderTrigger = 0) {
                 doPrerender(pageNumber, prerenderTrigger);
             }).catch(handleRenderingError);
         }).catch(handleRenderingError);
-    });
+    }).catch(handleRenderingError);
 }
 
 function requestRender(renderMode) {

--- a/viewer/js/index.js
+++ b/viewer/js/index.js
@@ -9,11 +9,15 @@ import { getSimplifiedOutline } from "./outline.js";
 
 GlobalWorkerOptions.workerSrc = "/viewer/js/worker.js";
 
+const RENDER_MODE_DEFAULT = 0;
+const RENDER_MODE_FINAL_ZOOM = 1;
+const RENDER_MODE_TRANSIENT_ZOOM = 2;
+
 let pdfDoc = null;
 let outlineAbort = new AbortController();
 let pageRendering = false;
 let renderPending = false;
-let renderPendingZoom = 0;
+let renderPendingMode = RENDER_MODE_DEFAULT;
 const canvas = document.getElementById("content");
 const container = document.getElementById("container");
 let orientationDegrees = 0;
@@ -35,7 +39,7 @@ function maybeRenderNextPage() {
     if (renderPending) {
         pageRendering = false;
         renderPending = false;
-        renderPage(channel.getPage(), renderPendingZoom, false);
+        renderPage(channel.getPage(), renderPendingMode, false);
         return true;
     }
     return false;
@@ -51,24 +55,24 @@ function handleRenderingError(error) {
 function doPrerender(pageNumber, prerenderTrigger) {
     if (useRender) {
         if (pageNumber + 1 <= pdfDoc.numPages) {
-            renderPage(pageNumber + 1, false, true, pageNumber);
+            renderPage(pageNumber + 1, RENDER_MODE_DEFAULT, true, pageNumber);
         } else if (pageNumber - 1 > 0) {
-            renderPage(pageNumber - 1, false, true, pageNumber);
+            renderPage(pageNumber - 1, RENDER_MODE_DEFAULT, true, pageNumber);
         }
     } else if (pageNumber === prerenderTrigger + 1) {
         if (prerenderTrigger - 1 > 0) {
-            renderPage(prerenderTrigger - 1, false, true, prerenderTrigger);
+            renderPage(prerenderTrigger - 1, RENDER_MODE_DEFAULT, true, prerenderTrigger);
         }
     }
 }
 
-function display(newCanvas, zoom) {
+function display(newCanvas, renderMode) {
     canvas.height = newCanvas.height;
     canvas.width = newCanvas.width;
     canvas.style.height = newCanvas.style.height;
     canvas.style.width = newCanvas.style.width;
     canvas.getContext("2d", { alpha: false }).drawImage(newCanvas, 0, 0);
-    if (!zoom) {
+    if (renderMode === RENDER_MODE_DEFAULT) {
         scrollTo(0, 0);
     }
 }
@@ -103,7 +107,15 @@ function getDefaultZoomRatio(page, degrees) {
     return Math.max(Math.min(widthZoomRatio, heightZoomRatio, channel.getMaxZoomRatio()), channel.getMinZoomRatio());
 }
 
-function renderPage(pageNumber, zoom, prerender, prerenderTrigger = 0) {
+function isFinalZoomRender(renderMode) {
+    return renderMode === RENDER_MODE_FINAL_ZOOM;
+}
+
+function isTransientZoomRender(renderMode) {
+    return renderMode === RENDER_MODE_TRANSIENT_ZOOM;
+}
+
+function renderPage(pageNumber, renderMode, prerender, prerenderTrigger = 0) {
     pageRendering = true;
     useRender = !prerender;
 
@@ -112,7 +124,7 @@ function renderPage(pageNumber, zoom, prerender, prerenderTrigger = 0) {
     orientationDegrees = channel.getDocumentOrientationDegrees();
     console.log("page: " + pageNumber + ", zoom: " + newZoomRatio +
                 ", orientationDegrees: " + orientationDegrees + ", prerender: " + prerender);
-    for (let i = 0; !zoom && i < cache.length; i++) {
+    for (let i = 0; renderMode === RENDER_MODE_DEFAULT && i < cache.length; i++) {
         const cached = cache[i];
         if (cached.pageNumber === pageNumber && cached.zoomRatio === newZoomRatio &&
                 cached.orientationDegrees === orientationDegrees) {
@@ -120,7 +132,7 @@ function renderPage(pageNumber, zoom, prerender, prerenderTrigger = 0) {
                 cache.splice(i, 1);
                 cache.push(cached);
 
-                display(cached.canvas, zoom);
+                display(cached.canvas, renderMode);
                 zoomRatio = newZoomRatio;
 
                 textLayerDiv.replaceWith(cached.textLayerDiv);
@@ -163,12 +175,12 @@ function renderPage(pageNumber, zoom, prerender, prerenderTrigger = 0) {
             zoomRatio = newZoomRatio;
         }
 
-        if (zoom === 1 || zoom === 2) {
+        if (isFinalZoomRender(renderMode) || isTransientZoomRender(renderMode)) {
             // Focus point in CSS px, in viewport coordinates.
-            const focusX = zoom === 2
+            const focusX = isTransientZoomRender(renderMode)
                 ? channel.getZoomFocusX() / ratio
                 : globalThis.innerWidth / 2;
-            const focusY = zoom === 2
+            const focusY = isTransientZoomRender(renderMode)
                 ? channel.getZoomFocusY() / ratio
                 : globalThis.innerHeight / 2;
 
@@ -179,7 +191,7 @@ function renderPage(pageNumber, zoom, prerender, prerenderTrigger = 0) {
             const translationFactor = scaleFactor - 1;
             scrollBy(globalFocusX * translationFactor, globalFocusY * translationFactor);
 
-            if (zoom === 2) {
+            if (isTransientZoomRender(renderMode)) {
                 textLayerDiv.hidden = true;
                 pageRendering = false;
                 return;
@@ -230,7 +242,7 @@ function renderPage(pageNumber, zoom, prerender, prerenderTrigger = 0) {
                 if (!useRender || rendered) {
                     return;
                 }
-                display(newCanvas, zoom);
+                display(newCanvas, renderMode);
                 rendered = true;
             }
             render();
@@ -278,8 +290,8 @@ function renderPage(pageNumber, zoom, prerender, prerenderTrigger = 0) {
     });
 }
 
-globalThis.onRenderPage = function (zoom) {
-    if (zoom === 1 || zoom === 2) {
+function requestRender(renderMode) {
+    if (isFinalZoomRender(renderMode) || isTransientZoomRender(renderMode)) {
         userZoomed = true;
     }
 
@@ -291,14 +303,26 @@ globalThis.onRenderPage = function (zoom) {
         }
 
         renderPending = true;
-        renderPendingZoom = zoom;
+        renderPendingMode = renderMode;
         if (task !== null) {
             task.cancel();
             task = null;
         }
     } else {
-        renderPage(channel.getPage(), zoom, false);
+        renderPage(channel.getPage(), renderMode, false);
     }
+}
+
+globalThis.renderDefault = function () {
+    requestRender(RENDER_MODE_DEFAULT);
+};
+
+globalThis.renderFinalZoom = function () {
+    requestRender(RENDER_MODE_FINAL_ZOOM);
+};
+
+globalThis.renderTransientZoom = function () {
+    requestRender(RENDER_MODE_TRANSIENT_ZOOM);
 };
 
 globalThis.isTextSelected = function () {
@@ -382,7 +406,7 @@ globalThis.loadDocument = function () {
         }).catch(function(error) {
             console.log("getOutline error: " + error);
         });
-        renderPage(channel.getPage(), false, false);
+        renderPage(channel.getPage(), RENDER_MODE_DEFAULT, false);
     }, function (reason) {
         console.error(reason.name + ": " + reason.message);
         channel.onLoadError();
@@ -397,7 +421,7 @@ globalThis.onresize = () => {
             const degrees = channel.getDocumentOrientationDegrees();
             const newDefaultZoom = getDefaultZoomRatio(page, degrees);
             channel.setZoomRatio(newDefaultZoom);
-            globalThis.onRenderPage(0);
+            requestRender(RENDER_MODE_DEFAULT);
         }).catch(function(err) {
             console.log("onresize error: " + err);
         });

--- a/viewer/js/index.js
+++ b/viewer/js/index.js
@@ -243,9 +243,6 @@ function renderPage(pageNumber, renderMode, prerender, prerenderTrigger = 0) {
         // use original viewport height for CSS zoom
         newCanvas.style.height = viewport.height + "px";
         newCanvas.style.width = viewport.width + "px";
-        const newContext = newCanvas.getContext("2d", { alpha: false });
-        newContext.scale(ratio, ratio);
-
         // Add padding to the canvas to allow the page to be scrolled bellow/above any
         // system/app ui that might be visible.
         canvas.style.paddingLeft = (channel.getInsetLeft() / ratio) + "px";
@@ -254,7 +251,9 @@ function renderPage(pageNumber, renderMode, prerender, prerenderTrigger = 0) {
         canvas.style.paddingBottom = (channel.getInsetBottom() / ratio) + "px";
 
         task = page.render({
-            canvasContext: newContext,
+            canvas: newCanvas,
+            // Scale both axes by the device pixel ratio, with no skew or translation.
+            transform: ratio === 1 ? null : [ratio, 0, 0, ratio, 0, 0],
             viewport: newViewport
         });
 


### PR DESCRIPTION
- CTRL + mouse wheel zooming
- Arrow keys for changing pages
- Haptic feedback for swiping to change pages
- Prevent mouse swiping from changing pages
- Use the recommended pdf.js canvas rendering API[^1][^2] to avoid black rectangles when rendering PDFs in WebView desktop mode. `canvasContext` is currently only being provided in pdf.js API for backwards compatibility

[^1]: https://github.com/mozilla/pdf.js/blob/v6.2.108/src/display/api.js#L1205-L1214
[^2]: https://github.com/mozilla/pdf.js/blob/v6.2.108/web/pdf_page_view.js#L1175-L1180